### PR TITLE
Change test cases to avoid name conflicts in C#

### DIFF
--- a/formats/instance_io_user.ksy
+++ b/formats/instance_io_user.ksy
@@ -9,7 +9,7 @@ seq:
     repeat: expr
     repeat-expr: qty_entries
   - id: strings
-    type: strings
+    type: strings_obj
     size-eos: true
 types:
   entry:
@@ -24,7 +24,7 @@ types:
         pos: name_ofs
         type: strz
         encoding: UTF-8
-  strings:
+  strings_obj:
     seq:
       - id: str
         type: strz

--- a/formats/nav_parent.ksy
+++ b/formats/nav_parent.ksy
@@ -3,17 +3,17 @@ meta:
   endian: le
 seq:
   - id: header
-    type: header
+    type: header_obj
   - id: index
-    type: index
+    type: index_obj
 types:
-  header:
+  header_obj:
     seq:
       - id: qty_entries
         type: u4
       - id: filename_len
         type: u4
-  index:
+  index_obj:
     seq:
       - id: magic
         size: 4

--- a/formats/nav_root.ksy
+++ b/formats/nav_root.ksy
@@ -3,17 +3,17 @@ meta:
   endian: le
 seq:
   - id: header
-    type: header
+    type: header_obj
   - id: index
-    type: index
+    type: index_obj
 types:
-  header:
+  header_obj:
     seq:
       - id: qty_entries
         type: u4
       - id: filename_len
         type: u4
-  index:
+  index_obj:
     seq:
       - id: magic
         size: 4

--- a/formats/position_abs.ksy
+++ b/formats/position_abs.ksy
@@ -5,7 +5,7 @@ seq:
   - id: index_offset
     type: u4
 types:
-  index:
+  index_obj:
     seq:
      - id: entry
        type: strz
@@ -13,4 +13,4 @@ types:
 instances:
   index:
     pos: index_offset
-    type: index
+    type: index_obj

--- a/formats/position_in_seq.ksy
+++ b/formats/position_in_seq.ksy
@@ -7,11 +7,11 @@ seq:
     repeat: expr
     repeat-expr: header.qty_numbers
 types:
-  header:
+  header_obj:
     seq:
       - id: qty_numbers
         type: u4
 instances:
   header:
     pos: 0x10
-    type: header
+    type: header_obj


### PR DESCRIPTION
These 5 unit tests have a naming conflict in C#, the fix mentioned in kaitai-io/kaitai_struct_compiler#2 was to rename the tests for now. I've appended `_obj` onto the conflicting class names to fix the issue. I don't think any unit tests need to change because they shouldn't refer to the class by name.