### PR TITLE
Partial compilation script for C#

### DIFF
--- a/config
+++ b/config
@@ -2,6 +2,7 @@ COMPILER_DIR=../compiler
 FORMATS_KSY_DIR=formats
 FORMATS_COMPILED_DIR=compiled
 
+CSHARP_RUNTIME_DIR=../runtime/csharp
 JAVA_RUNTIME_DIR=../runtime/java
 JAVA_TESTNG_JAR=$HOME/.m2/repository/org/testng/testng/6.9.10/testng-6.9.10.jar:$HOME/.m2/repository/com/beust/jcommander/1.48/jcommander-1.48.jar
 JAVASCRIPT_RUNTIME_DIR=../runtime/javascript

--- a/run-csharp
+++ b/run-csharp
@@ -5,72 +5,53 @@
 CSHARP_TEST_FORMATS_DIR=$FORMATS_COMPILED_DIR/csharp
 CSHARP_SPEC_DIR=spec/csharp
 CSHARP_TEST_OUT_DIR="$TEST_OUT_DIR"/csharp
+CSHARP_COMPILE_LOG="$CSHARP_TEST_OUT_DIR/_compile.log"
 
 rm -rf "$CSHARP_TEST_OUT_DIR"
 mkdir -p "$CSHARP_TEST_OUT_DIR"
 
 # Try and build the project first - if there's no compile errors, we can continue straight away
 echo "run-csharp: building project"
-xbuild "$CSHARP_SPEC_DIR/kaitai_struct_csharp_tests.sln" >> "$CSHARP_TEST_OUT_DIR/_compile.log" || {
+xbuild "$CSHARP_SPEC_DIR/kaitai_struct_csharp_tests.sln" >> "$CSHARP_COMPILE_LOG" || {
 
     # Some formats failed to build - find the failing files and erase them
-	echo "run-csharp: some formats failed to compile, checking each file individually"
+    echo "run-csharp: some formats failed to compile, checking each file individually"
     
     # Find the invalid files and wipe them - we do this by scanning the error list from the compiler
     mcs \
         -t:library \
         -fullpaths \
-        -o:$CSHARP_TEST_OUT_DIR/_cs_compile_temp.dll \
+        -warn:0 \
         -r:"$CSHARP_SPEC_DIR/packages/NUnit.3.4.1/lib/net45/nunit.framework.dll" \
         "$CSHARP_RUNTIME_DIR/*.cs" \
         "$CSHARP_SPEC_DIR/kaitai_struct_csharp_tests/CommonSpec.cs" \
         "$CSHARP_TEST_FORMATS_DIR"/*.cs \
-            2>&1 >> "$CSHARP_TEST_OUT_DIR/_compile.log" | \
-            while read -r line ; do
-                # e.g. path/to/file.cs(1): Unexpected symbol
-                # Grab everything before the first '(' character
-                FILENAME=$(echo $line | cut -d '(' -f 1)
-                if [ -s $FILENAME ]
-                then
-                    NAME=$(basename "$FILENAME")
-                    echo "$NAME failed to compile, removing"
-                    > $FILENAME
-                fi
-            done
+            2>&1 >> "$CSHARP_COMPILE_LOG" | \
+            fgrep '(' | cut -d'(' -f1 | xargs -d '\n' truncate -c -s0
     
-	echo "run-csharp: removing tests that are no longer valid"
+    echo "run-csharp: removing tests that are no longer valid"
     
     # Now that the invalid spec classes are gone, we need to remove the matching test cases
     mcs \
         -t:library \
         -fullpaths \
-        -o:$CSHARP_TEST_OUT_DIR/_cs_compile_temp.dll \
+        -warn:0 \
         -r:"$CSHARP_SPEC_DIR/packages/NUnit.3.4.1/lib/net45/nunit.framework.dll" \
         "$CSHARP_RUNTIME_DIR/*.cs" \
         "$CSHARP_SPEC_DIR/kaitai_struct_csharp_tests/CommonSpec.cs" \
         "$CSHARP_TEST_FORMATS_DIR"/*.cs \
         "$CSHARP_SPEC_DIR/kaitai_struct_csharp_tests/tests/*.cs" \
-            2>&1 >> "$CSHARP_TEST_OUT_DIR/_compile.log" | \
-            while read -r line ; do
-                # e.g. path/to/file.cs(1): Unexpected symbol
-                # Grab everything before the first '(' character
-                FILENAME=$(echo $line | cut -d '(' -f 1)
-                if [ -s $FILENAME ]
-                then
-                    NAME=$(basename "$FILENAME")
-                    echo "The $NAME test was removed as there was no matching spec"
-                    > $FILENAME
-                fi
-            done
+            2>&1 >> "$CSHARP_COMPILE_LOG" | \
+            fgrep '(' | cut -d'(' -f1 | xargs -d '\n' truncate -c -s0
     
     # Invalid tests should all be gone - rebuild the project
     echo "run-csharp: rebuilding project"
-    xbuild "$CSHARP_SPEC_DIR/kaitai_struct_csharp_tests.sln" >> "$CSHARP_TEST_OUT_DIR/_compile.log"
+    xbuild "$CSHARP_SPEC_DIR/kaitai_struct_csharp_tests.sln" >> "$CSHARP_COMPILE_LOG"
 }
 
 # Actually run the tests
 mkdir -p "$TEST_OUT_DIR/csharp"
 mono \
-	"$CSHARP_SPEC_DIR/packages/NUnit.ConsoleRunner.3.4.1/tools/nunit3-console.exe" \
-	--result="$TEST_OUT_DIR/csharp/TestResult.xml" \
-	"$CSHARP_SPEC_DIR/kaitai_struct_csharp_tests/bin/Debug/kaitai_struct_csharp_tests.dll"
+    "$CSHARP_SPEC_DIR/packages/NUnit.ConsoleRunner.3.4.1/tools/nunit3-console.exe" \
+    --result="$TEST_OUT_DIR/csharp/TestResult.xml" \
+    "$CSHARP_SPEC_DIR/kaitai_struct_csharp_tests/bin/Debug/kaitai_struct_csharp_tests.dll"

--- a/run-csharp
+++ b/run-csharp
@@ -2,10 +2,71 @@
 
 . ./config
 
+CSHARP_TEST_FORMATS_DIR=$FORMATS_COMPILED_DIR/csharp
 CSHARP_SPEC_DIR=spec/csharp
+CSHARP_TEST_OUT_DIR="$TEST_OUT_DIR"/csharp
 
-# Compile everything
-xbuild "$CSHARP_SPEC_DIR/kaitai_struct_csharp_tests.sln"
+rm -rf "$CSHARP_TEST_OUT_DIR"
+mkdir -p "$CSHARP_TEST_OUT_DIR"
+
+# Try and build the project first - if there's no compile errors, we can continue straight away
+echo "run-csharp: building project"
+xbuild "$CSHARP_SPEC_DIR/kaitai_struct_csharp_tests.sln" >> "$CSHARP_TEST_OUT_DIR/_compile.log" || {
+
+    # Some formats failed to build - find the failing files and erase them
+	echo "run-csharp: some formats failed to compile, checking each file individually"
+    
+    # Find the invalid files and wipe them - we do this by scanning the error list from the compiler
+    mcs \
+        -t:library \
+        -fullpaths \
+        -o:$CSHARP_TEST_OUT_DIR/_cs_compile_temp.dll \
+        -r:"$CSHARP_SPEC_DIR/packages/NUnit.3.4.1/lib/net45/nunit.framework.dll" \
+        "$CSHARP_RUNTIME_DIR/*.cs" \
+        "$CSHARP_SPEC_DIR/kaitai_struct_csharp_tests/CommonSpec.cs" \
+        "$CSHARP_TEST_FORMATS_DIR"/*.cs \
+            2>&1 >> "$CSHARP_TEST_OUT_DIR/_compile.log" | \
+            while read -r line ; do
+                # e.g. path/to/file.cs(1): Unexpected symbol
+                # Grab everything before the first '(' character
+                FILENAME=$(echo $line | cut -d '(' -f 1)
+                if [ -s $FILENAME ]
+                then
+                    NAME=$(basename "$FILENAME")
+                    echo "$NAME failed to compile, removing"
+                    > $FILENAME
+                fi
+            done
+    
+	echo "run-csharp: removing tests that are no longer valid"
+    
+    # Now that the invalid spec classes are gone, we need to remove the matching test cases
+    mcs \
+        -t:library \
+        -fullpaths \
+        -o:$CSHARP_TEST_OUT_DIR/_cs_compile_temp.dll \
+        -r:"$CSHARP_SPEC_DIR/packages/NUnit.3.4.1/lib/net45/nunit.framework.dll" \
+        "$CSHARP_RUNTIME_DIR/*.cs" \
+        "$CSHARP_SPEC_DIR/kaitai_struct_csharp_tests/CommonSpec.cs" \
+        "$CSHARP_TEST_FORMATS_DIR"/*.cs \
+        "$CSHARP_SPEC_DIR/kaitai_struct_csharp_tests/tests/*.cs" \
+            2>&1 >> "$CSHARP_TEST_OUT_DIR/_compile.log" | \
+            while read -r line ; do
+                # e.g. path/to/file.cs(1): Unexpected symbol
+                # Grab everything before the first '(' character
+                FILENAME=$(echo $line | cut -d '(' -f 1)
+                if [ -s $FILENAME ]
+                then
+                    NAME=$(basename "$FILENAME")
+                    echo "The $NAME test was removed as there was no matching spec"
+                    > $FILENAME
+                fi
+            done
+    
+    # Invalid tests should all be gone - rebuild the project
+    echo "run-csharp: rebuilding project"
+    xbuild "$CSHARP_SPEC_DIR/kaitai_struct_csharp_tests.sln" >> "$CSHARP_TEST_OUT_DIR/_compile.log"
+}
 
 # Actually run the tests
 mkdir -p "$TEST_OUT_DIR/csharp"


### PR DESCRIPTION
Similar to the `run-java` script, but for C#. Should resolve kaitai-io/kaitai_struct#6. Tested in Bash on Windows - I don't do a lot of Bash scripting so please check it's okay!

There's a few things to note:

- `msbuild`/`xbuild` should be used the build the project/solution, because it can contain commands aside from just the compile step (such as copying files)
- `xbuild` doesn't like when a file is missing, so I'm just clearing the contents of the file instead
- Invalid files are found by running `mcs` and scanning stderr for the files that contain errors
- Once .NET Core has been changed to work with `.csproj` files ([Q1 2017](https://blogs.msdn.microsoft.com/dotnet/2016/07/15/net-core-roadmap/)) it might be a good idea to switch from Mono to .NET Core for the build

The output of `mcs` has the file name for each error, each line is chopped at the first `(` character and that file is erased if it's not already blank.

    /kaitai_struct/tests/compiled/csharp/DefaultBigEndian.cs(32,246): error CS1525: Unexpected symbol `end-of-file'
    echo $line | cut -d '(' -f 1
    /kaitai_struct/tests/compiled/csharp/DefaultBigEndian.cs
