### PR TITLE
Fixed the RepeatUntilS4Test

### DIFF
--- a/spec/php/RepeatUntilS4Test.php
+++ b/spec/php/RepeatUntilS4Test.php
@@ -3,7 +3,7 @@ namespace Kaitai\Struct\Tests;
 
 class RepeatUntilS4Test extends TestCase {
     public function testRepeatUntilS4() {
-        $r = RepeatUntilS4::fromFile(self::SRC_DIR_PATH . "/repeat_n_struct.bin");
+        $r = RepeatUntilS4::fromFile(self::SRC_DIR_PATH . "/repeat_until_s4.bin");
 
         $this->assertEquals([0x42, 0x1337, -251658241, -1], $r->entries);
         $this->assertEquals("foobar", $r->afterall);

--- a/spec/php/phpunit.xml
+++ b/spec/php/phpunit.xml
@@ -1,0 +1,7 @@
+<phpunit bootstrap="_bootstrap.php" colors="false" verbose="true" beStrictAboutTestsThatDoNotTestAnything="true">
+    <testsuites>
+        <testsuite>
+            <directory>.</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>


### PR DESCRIPTION
The file RepeatUntilS4.php has the following line:
```php
        $this->afterall = $this->_io->readStrz("ASCII", 0, false, true, true);
```
it should be changed to the:
```php
        $this->afterall = $this->_io->readStrz("ASCII", "\x00", false, true, true);
```
The 0 is integer, but actual byte's value will be a character with the ASCII code 0, not an integer. The character with the code 0 can be encoded as string "\x00" in PHP.

Of course I could add a check and conversion to the character from the ASCII code:
```php
if (is_int($terminator)) {
    $terminator = chr($terminator);
}
```
But would it make a sense? I don't think that this is required as the bytes represented as hex strings in PHP.