### PR TITLE
Fixed Enum0Test, Expr0Test, Expr1Test

### DIFF
--- a/spec/php/Enum0Test.php
+++ b/spec/php/Enum0Test.php
@@ -3,12 +3,8 @@ namespace Kaitai\Struct\Tests;
 
 class Enum0Test extends TestCase {
     public function testEnum0() {
-        $this->markTestIncomplete();
-/*
-        Enum0 r = Enum0::fromFile(self::SRC_DIR_PATH . "enum_0.bin");
-
-        $this->assertEquals(r.pet1(), Enum0.Animal.CAT);
-        $this->assertEquals(r.pet2(), Enum0.Animal.CHICKEN);
-*/    
+        $r = Enum0::fromFile(self::SRC_DIR_PATH . "/enum_0.bin");
+        $this->assertEquals($r->pet1(), Enum0::Animal()::CAT);
+        $this->assertEquals($r->pet2(), Enum0::Animal()::CHICKEN);
     }
 }

--- a/spec/php/Expr0Test.php
+++ b/spec/php/Expr0Test.php
@@ -4,8 +4,7 @@ namespace Kaitai\Struct\Tests;
 class Expr0Test extends TestCase {
     public function testExpr0() {
         $r = Expr0::fromFile(self::SRC_DIR_PATH . "/str_encodings.bin");
-
-        $this->assertEquals(0xf7, $r->mustBeF7->intValue);
+        $this->assertEquals(0xf7, $r->mustBeF7);
         $this->assertEquals("abc123", $r->mustBeAbc123);
     }
 }

--- a/spec/php/Expr1Test.php
+++ b/spec/php/Expr1Test.php
@@ -3,14 +3,11 @@ namespace Kaitai\Struct\Tests;
 
 class Expr1Test extends TestCase {
     public function testExpr1() {
-        $this->markTestIncomplete();
-/*
-        Expr1 r = Expr1::fromFile(self::SRC_DIR_PATH . "str_encodings.bin");
+        $r = Expr1::fromFile(self::SRC_DIR_PATH . "/str_encodings.bin");
 
-        $this->assertEquals(r.lenOf1(), 10);
-        $this->assertEquals(r.lenOf1Mod().intValue(), 8);
-        $this->assertEquals(r.str1(), "Some ASC");
-        $this->assertEquals(r.str1Len().intValue(), 8);
-*/    
+        $this->assertEquals($r->lenOf1(), 10);
+        $this->assertEquals($r->lenOf1Mod(), 8);
+        $this->assertEquals($r->str1(), "Some ASC");
+        $this->assertEquals($r->str1Len(), 8);
     }
 }


### PR DESCRIPTION
Enum0:
```php
<?php
// This is a generated file! Please edit source .ksy file and use kaitai-struct-compiler to rebuild

namespace Kaitai\Struct\Tests;

class Enum0 extends \Kaitai\Struct\Struct {
    public function __construct(\Kaitai\Struct\Stream $io, \Kaitai\Struct\Struct $parent = null, Enum0 $root = null) {
        parent::__construct($io, $parent, $root);
        $this->_parse();
    }

    private function _parse() {
        self::$Animal = new Enum0\Animal;
        $this->pet1 = $this->_io->readU4le();
        $this->pet2 = $this->_io->readU4le();
    }

    protected $pet1;
    protected $pet2;
    protected static $Animal;

    public function pet1() { return $this->pet1; }

    public function pet2() { return $this->pet2; }

    public static function Animal() {
        return self::$Animal;
    }
}

namespace Kaitai\Struct\Tests\Enum0;

class Animal {
    const DOG = 4;
    const CAT = 7;
    const CHICKEN = 12;
}
```

Expr0:
```php
<?php
// This is a generated file! Please edit source .ksy file and use kaitai-struct-compiler to rebuild

namespace Kaitai\Struct\Tests;

class Expr0 extends \Kaitai\Struct\Struct {
    public function __construct(\Kaitai\Struct\Stream $io, \Kaitai\Struct\Struct $parent = null, Expr0 $root = null) {
        parent::__construct($io, $parent, $root);
        $this->_parse();
    }
    private function _parse() {
        $this->lenOf1 = $this->_io->readU2le();
    }
    private $mustBeF7;
    public function mustBeF7(): int {
        if ($this->mustBeF7 !== null)
            return $this->mustBeF7;
        $this->mustBeF7 = (7 + 240);
        return $this->mustBeF7;
    }
    private $mustBeAbc123;
    public function mustBeAbc123(): string {
        if ($this->mustBeAbc123 !== null)
            return $this->mustBeAbc123;
        $this->mustBeAbc123 = "abc" . "123";
        return $this->mustBeAbc123;
    }
    protected $lenOf1;
    public function lenOf1() { return $this->lenOf1; }
}
```

Expr1:
```php
<?php
// This is a generated file! Please edit source .ksy file and use kaitai-struct-compiler to rebuild

namespace Kaitai\Struct\Tests;

class Expr1 extends \Kaitai\Struct\Struct {
    public function __construct(\Kaitai\Struct\Stream $io, \Kaitai\Struct\Struct $parent = null, Expr1 $root = null) {
        parent::__construct($io, $parent, $root);
        $this->_parse();
    }
    private function _parse() {
        $this->lenOf1 = $this->_io->readU2le();
        $this->str1 = $this->_io->readStrByteLimit($this->lenOf1Mod(), "ASCII");
    }

    protected $lenOf1Mod;
    public function lenOf1Mod(): int {
        if ($this->lenOf1Mod !== null)
            return $this->lenOf1Mod;
        $this->lenOf1Mod = ($this->lenOf1 - 2);
        return $this->lenOf1Mod;
    }
    protected $str1Len;
    public function str1Len(): int {
        if ($this->str1Len !== null)
            return $this->str1Len;
        $this->str1Len = strlen($this->str1);
        return $this->str1Len;
    }
    protected $lenOf1;
    protected $str1;
    public function lenOf1() { return $this->lenOf1; }
    public function str1() { return $this->str1; }
}
```

In the Enum0 the `self::$Animal = new Enum0\Animal;` can be written differently also `self::$Animal = new \Kaitai\Struct\TestsEnum0\Animal;`. Any variant can be chosen. If full names more easy to implement we could use them.