### PR TITLE
https://github.com/kaitai-io/kaitai_struct_tests/issues/18

### DIFF
--- a/run-javascript
+++ b/run-javascript
@@ -5,8 +5,7 @@
 # (Note: On Windows, NODE_PATH is delimited by semicolons instead of colons.)
 # https://nodejs.org/api/modules.html#modules_loading_from_the_global_folders
 DIVIDER=":"
-if [ ${OS} = "Windows_NT" ]
-then
+if [ "$OS" = "Windows_NT" ]; then
 	DIVIDER=";"
 fi
 

--- a/run-javascript
+++ b/run-javascript
@@ -2,5 +2,13 @@
 
 . ./config
 
-NODE_PATH=compiled/javascript:helpers/javascript:$JAVASCRIPT_MODULES_DIR:$JAVASCRIPT_RUNTIME_DIR \
+# (Note: On Windows, NODE_PATH is delimited by semicolons instead of colons.)
+# https://nodejs.org/api/modules.html#modules_loading_from_the_global_folders
+DIVIDER=":"
+if [ ${OS} = "Windows_NT" ]
+then
+	DIVIDER=";"
+fi
+
+NODE_PATH="compiled/javascript${DIVIDER}helpers/javascript${DIVIDER}$JAVASCRIPT_MODULES_DIR${DIVIDER}$JAVASCRIPT_RUNTIME_DIR" \
 	$JAVASCRIPT_MODULES_DIR/mocha/bin/mocha spec/javascript

--- a/run-ruby
+++ b/run-ruby
@@ -6,7 +6,7 @@
 # work if Ruby is installed in a path with spaces, but is used by default in environments like Git
 # Bash.
 if [ "$OS" = "Windows_NT" ]; then
-	EXEC_EXT=.bat
+	EXEC_EXT=".bat"
 fi
 
 rspec${EXEC_EXT} -I compiled/ruby -I "$RUBY_RUNTIME_DIR"

--- a/run-ruby
+++ b/run-ruby
@@ -2,4 +2,11 @@
 
 . ./config
 
-rspec -I compiled/ruby -I "$RUBY_RUNTIME_DIR"
+# rspec is available with and without extension in Windows and the file without extension doesn't
+# work if Ruby is installed in a path with spaces, but is used by default in environments like Git
+# Bash.
+if [ "$OS" = "Windows_NT" ]; then
+	EXEC_EXT=.bat
+fi
+
+rspec${EXEC_EXT} -I compiled/ruby -I "$RUBY_RUNTIME_DIR"


### PR DESCRIPTION
Some improvements to be able to use the run-scripts under Windows in Git Bash without modifications. One is for JavaScript because node.js uses `;` instead of `:` as dir delimiter and the other for Ruby, if this is installed in a path containing spaces. Under Git Bash, not the `.bat` file for `rspec` is used by default, but the Posix like one which does contain a shebang like the following:

> #!"C:/Program Files (x86)/Ruby23/bin/ruby.exe"

This isn't executed properly, even though Ruby generates this file on its own. Using the `.bat` file instead running the script works.