### PR TITLE
#38: Test wrong derivation of _parent in value instances

### DIFF
--- a/formats/parent_vs_value_inst.ksy
+++ b/formats/parent_vs_value_inst.ksy
@@ -1,0 +1,18 @@
+# https://github.com/kaitai-io/kaitai_struct_compiler/issues/38#issuecomment-265525999
+meta:
+  id: parent_vs_value_inst
+  endian: le
+
+seq:
+  - id: s1
+    type: strz
+    encoding: UTF-8
+    terminator: 0x7C
+  - id: child
+    type: child
+
+types:
+  child:
+    instances:
+      do_something:
+        value: "_parent.s1 == 'foo' ? true : false"

--- a/spec/ruby/parent_vs_value_inst_spec.rb
+++ b/spec/ruby/parent_vs_value_inst_spec.rb
@@ -1,0 +1,9 @@
+require 'parent_vs_value_inst'
+
+RSpec.describe ParentVsValueInst do
+  it 'parses test properly' do
+    r = ParentVsValueInst.from_file('src/term_strz.bin')
+
+    expect(r.s1).to eq('foo')
+  end
+end


### PR DESCRIPTION
This is a corresponding test, which should fail during `build-formats` already or simply work.