### PR TITLE
#39: Invalid "switch"-statement generated for Java.

### DIFF
--- a/formats/switch_multi_bool_ops.ksy
+++ b/formats/switch_multi_bool_ops.ksy
@@ -1,0 +1,22 @@
+meta:
+  id: switch_multi_bool_ops
+  endian: le
+seq:
+  - id: opcodes
+    type: opcode
+    repeat: eos
+types:
+  opcode:
+    seq:
+      - id: code
+        type: u1
+      - id: body
+        type:
+          switch-on: "(  (code >   0) and
+                         (code <=  8) and
+                        ((code != 10) ? true : false)) ? code : 0"
+          cases:
+            1: u1
+            2: u2
+            4: u4
+            8: u8

--- a/formats/switch_multi_bool_ops.ksy
+++ b/formats/switch_multi_bool_ops.ksy
@@ -1,3 +1,4 @@
+# https://github.com/kaitai-io/kaitai_struct_compiler/issues/39
 meta:
   id: switch_multi_bool_ops
   endian: le

--- a/spec/ruby/switch_multi_bool_ops_spec.rb
+++ b/spec/ruby/switch_multi_bool_ops_spec.rb
@@ -4,6 +4,18 @@ RSpec.describe SwitchMultiBoolOps do
   it 'parses test properly' do
     r = SwitchMultiBoolOps.from_file('src/switch_integers.bin')
 
-    # The test just needs to compile/execute, we don't care about actual data.
+    expect(r.opcodes.size).to eq 4
+
+    expect(r.opcodes[0].code).to eq 1
+    expect(r.opcodes[0].body).to eq 7
+
+    expect(r.opcodes[1].code).to eq 2
+    expect(r.opcodes[1].body).to eq 0x4040
+
+    expect(r.opcodes[2].code).to eq 4
+    expect(r.opcodes[2].body).to eq 4919
+
+    expect(r.opcodes[3].code).to eq 8
+    expect(r.opcodes[3].body).to eq 4919
   end
 end

--- a/spec/ruby/switch_multi_bool_ops_spec.rb
+++ b/spec/ruby/switch_multi_bool_ops_spec.rb
@@ -1,0 +1,9 @@
+require 'switch_multi_bool_ops'
+
+RSpec.describe SwitchMultiBoolOps do
+  it 'parses test properly' do
+    r = SwitchMultiBoolOps.from_file('src/switch_integers.bin')
+
+    # The test just needs to compile/execute, we don't care about actual data.
+  end
+end


### PR DESCRIPTION
In case of multiple boolean operations as condition of a switch statement, parenthesis weren't properly generated. This at least in Java created code which didn't compile.

https://github.com/kaitai-io/kaitai_struct_compiler/issues/39