### PR TITLE
Added a test to map value instances to an enum.

### DIFF
--- a/formats/enum_of_value_inst.ksy
+++ b/formats/enum_of_value_inst.ksy
@@ -1,0 +1,21 @@
+meta:
+  id: enum_of_value_inst
+  endian: le
+seq:
+  - id: pet_1
+    type: u4
+    enum: animal
+  - id: pet_2
+    type: u4
+    enum: animal
+enums:
+  animal:
+    4: dog
+    7: cat
+    12: chicken
+instances:
+  pet_3:
+    value: "pet_1 == animal::cat ? 4 : 12"
+    enum: animal
+  pet_4:
+    value: "pet_1 == animal::cat ? animal::dog : animal::chicken"

--- a/spec/ruby/enum_of_value_inst_spec.rb
+++ b/spec/ruby/enum_of_value_inst_spec.rb
@@ -1,0 +1,13 @@
+# coding: utf-8
+require 'enum_of_value_inst'
+
+RSpec.describe EnumOfValueInst do
+  it 'parses test properly' do
+    r = EnumOfValueInst.from_file('src/enum_0.bin')
+
+    expect(r.pet_1).to eq :animal_cat
+    expect(r.pet_2).to eq :animal_chicken
+    expect(r.pet_3).to eq :animal_dog
+    expect(r.pet_4).to eq :animal_dog
+  end
+end


### PR DESCRIPTION
I made a mistake in my KSY file, mapping a `value` instance already containing `enum` instances in a boolean operation/`Ast.expr.IfExp` to an `enum`: I used the keyword `enum` in this case, because I somehow thought that I need to provide the resulting data type for the value instance and that didn't work, because KS mapped the expression to `EnumById`. But there was no ID to map of course... I simply needed to not use the `enum` keyword in this case, but it took me quite some time to understand this.

I've added this test to make the difference easier to remember for me or simply have some example I can search for next time. Maybe you find it a bit useful for others and hope you're are merging it.