### PR TITLE
CalcIntType -> long, because int might lead to loss of data in some c…

### DIFF
--- a/spec/java/src/io/kaitai/struct/spec/TestTypeIntUnaryOp.java
+++ b/spec/java/src/io/kaitai/struct/spec/TestTypeIntUnaryOp.java
@@ -13,7 +13,7 @@ public class TestTypeIntUnaryOp extends CommonSpec {
 
         assertEquals(r.valueS2(), (short) 0x4150);
         assertEquals(r.valueS8(), 0x4150ffff312d4b43L);
-        assertTrue(r.unaryS2() instanceof Integer);
+        assertTrue(r.unaryS2() instanceof Long);
         assertTrue(r.unaryS8() instanceof Long);
         assertEquals(r.unaryS2().shortValue(), (short) -0x4150);
         assertEquals(r.unaryS8().longValue(), -0x4150ffff312d4b43L);


### PR DESCRIPTION
…alculations.

https://github.com/kaitai-io/kaitai_struct_compiler/issues/62