### PR TITLE
add testcase for testing bitfield-sizes between 32 bit and 64 bit

### DIFF
--- a/formats/bits_simple.ksy
+++ b/formats/bits_simple.ksy
@@ -27,6 +27,15 @@ seq:
   # byte 8-9-10 (24 bits)
   - id: byte_8_9_10
     type: b24
+  # byte 11-12-13-14 (32 bits)
+  - id: byte_11_to_14
+    type: b32
+  # byte 15-16-17-18-19 (40 bits)
+  - id: byte_15_to_19
+    type: b40
+  # byte 20-21-22-23-24-25-26-27 (64 bits)
+  - id: byte_20_to_27
+    type: b64
 instances:
   test_if_b1:
     value: 123

--- a/spec/cpp_stl/test_bits_simple.cpp
+++ b/spec/cpp_stl/test_bits_simple.cpp
@@ -31,6 +31,15 @@ BOOST_AUTO_TEST_CASE(test_bits_simple) {
     // 50 41 43
     BOOST_CHECK_EQUAL(r->byte_8_9_10(), 0x504143);
 
+    // 4B 2D 55 2D
+    BOOST_CHECK_EQUAL(r->byte_11_to_14(), 0x4B2D552D);
+
+    // 44 45 46 FF FF
+    BOOST_CHECK_EQUAL(r->byte_15_to_19(), 0x444546FFFF);
+
+    // FF FF FF FF FF FF FF FF
+    BOOST_CHECK_EQUAL(r->byte_20_to_27(), 0xFFFFFFFFFFFFFFFF);
+
     BOOST_CHECK_EQUAL(r->test_if_b1(), 123);
 
     delete r;


### PR DESCRIPTION
add testcase for reading
bitfields with size between 32 bit and 64 bit

At the moment this testcases fail for cpp_stl