### PR TITLE
update format error tests to pass with the latest compiler

### DIFF
--- a/formats_err/attr_bad_key.ksy
+++ b/formats_err/attr_bad_key.ksy
@@ -1,4 +1,4 @@
-# /seq/1/blah: unknown key found, expected: consume, contents, doc, eos-error, id, if, include, parent, process, repeat, size, size-eos, terminator, type
+# /seq/1/blah: unknown key found, expected: consume, contents, doc, doc-ref, eos-error, id, if, include, pad-right, parent, process, repeat, size, size-eos, terminator, type
 meta:
   id: attr_bad_key
   endian: le

--- a/formats_err/enum_unquoted_null.ksy
+++ b/formats_err/enum_unquoted_null.ksy
@@ -1,3 +1,4 @@
+# /enums/foo/0: expected string or map, got null
 meta:
   id: enum_unquoted_null
 enums:

--- a/formats_err/instance_value_null.ksy
+++ b/formats_err/instance_value_null.ksy
@@ -1,3 +1,4 @@
+# /instances/foo/value: expected string, got null
 meta:
   id: instance_value_null
 instances:

--- a/formats_err/instance_value_with_size.ksy
+++ b/formats_err/instance_value_with_size.ksy
@@ -1,4 +1,4 @@
-# /instances/foo/size: invalid key found in value instance, allowed: doc, enum, if, value
+# /instances/foo/size: invalid key found in value instance, allowed: doc, doc-ref, enum, if, value
 meta:
   id: instance_value_with_size
 instances:

--- a/formats_err/instance_value_with_type.ksy
+++ b/formats_err/instance_value_with_type.ksy
@@ -1,4 +1,4 @@
-# /instances/foo/type: invalid key found in value instance, allowed: doc, enum, if, value
+# /instances/foo/type: invalid key found in value instance, allowed: doc, doc-ref, enum, if, value
 meta:
   id: instance_value_with_type
 instances:

--- a/formats_err/meta_bad_key.ksy
+++ b/formats_err/meta_bad_key.ksy
@@ -1,4 +1,4 @@
-# /meta/foo: unknown key found, expected: application, encoding, endian, file-extension, id, ks-debug, ks-version, license, title
+# /meta/foo: unknown key found, expected: application, encoding, endian, file-extension, id, imports, ks-debug, ks-opaque-types, ks-version, license, title, xref
 meta:
   id: meta_bad_key
   foo: bad_key

--- a/formats_err/params_call_short_malformed.ksy
+++ b/formats_err/params_call_short_malformed.ksy
@@ -1,4 +1,4 @@
-# /seq/0: parsing expression '2 + 3, ' failed on 1:6
+# /seq/0: parsing expression '2 + 3, ' failed on 1:6, expected CharsWhile(Set( , n)) | "\\\n" | End
 meta:
   id: params_call_short_malformed
 seq:

--- a/formats_err/repeat_incompatible1.ksy
+++ b/formats_err/repeat_incompatible1.ksy
@@ -1,4 +1,4 @@
-# /seq/0/repeat-until: unknown key found, expected: consume, doc, eos-error, id, if, include, repeat, terminator, type
+# /seq/0/repeat-until: unknown key found, expected: consume, doc, doc-ref, eos-error, id, if, include, repeat, terminator, type
 meta:
   id: repeat_incompatible1
 seq:

--- a/formats_err/repeat_incompatible3.ksy
+++ b/formats_err/repeat_incompatible3.ksy
@@ -1,4 +1,4 @@
-# /seq/0/repeat-expr: unknown key found, expected: consume, doc, eos-error, id, if, include, repeat, repeat-until, terminator, type
+# /seq/0/repeat-expr: unknown key found, expected: consume, doc, doc-ref, eos-error, id, if, include, repeat, repeat-until, terminator, type
 meta:
   id: repeat_incompatible3
 seq:

--- a/formats_err/repeat_wo_repeat.ksy
+++ b/formats_err/repeat_wo_repeat.ksy
@@ -1,4 +1,4 @@
-# /seq/0/repeat-until: unknown key found, expected: consume, doc, eos-error, id, if, include, repeat, terminator, type
+# /seq/0/repeat-until: unknown key found, expected: consume, doc, doc-ref, eos-error, id, if, include, repeat, terminator, type
 meta:
   id: repeat_wo_repeat
 seq:

--- a/formats_err/switch_on_malformed.ksy
+++ b/formats_err/switch_on_malformed.ksy
@@ -1,4 +1,4 @@
-# /seq/0/switch-on: parsing expression '42/' failed on 1:3, expected "or" | CharsWhile(Set( , n)) | "\\\n" | End
+# /seq/0: parsing expression '42/' failed on 1:3, expected "or" | CharsWhile(Set( , n)) | "\\\n" | End
 meta:
   id: switch_on_malformed
 seq:


### PR DESCRIPTION
I updated tests under formats_err to make `sbt "testOnly io.kaitai.struct.ErrorMessagesSpec"` pass. By the way, can I try improving the test coverage of http://kaitai.io/ci/?  I'm also interested in improving coverage of type checks (for example, `[1, 'foo']` is rejected with `can't combine output types` and `[1, 3.14]` is accepted but there're no test cases for this. Also, `substring`, `to_i(radix)` do not seem to be tested).