### PR TITLE
Nim is ready for CI

### DIFF
--- a/aggregate/convert_to_json
+++ b/aggregate/convert_to_json
@@ -81,7 +81,7 @@ when 'java'
   )
 when 'lua', 'rust'
   JUnitXMLParser.new(infile).to_h
-when 'go', 'perl'
+when 'go', 'perl', 'nim'
   add_kst_adoption(
     JUnitXMLParser.new("#{infile}/report.xml").to_h,
     infile

--- a/aggregate/junit_xml_parser.rb
+++ b/aggregate/junit_xml_parser.rb
@@ -30,6 +30,9 @@ class JUnitXMLParser < TestParser
         elsif name =~ /^Test.*\.test_/
           # Lua output, use classname
           name = tc.attribute('classname').value.gsub(/^Test/, '')
+        elsif name =~ /^Nim: (.*?)$/
+          # Nim output, extract test from classname
+          name = $1
         else
           raise "Unable to parse name: \"#{name}\"" unless name =~ /^[Tt]est(.*?)$/
           if $1[0] == '_'

--- a/ci-nim
+++ b/ci-nim
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+. ./config
+
+rm -rf "$TEST_OUT_DIR/nim"
+mkdir -p "$TEST_OUT_DIR/nim"
+nim c -r --outdir:"$TEST_OUT_DIR/nim/bin" "spec/nim/generate_test_suite" "ci"
+nim c -r --outdir:"$TEST_OUT_DIR/nim/bin" "spec/nim/test" 
+
+touch "$TEST_OUT_DIR/nim/kst_adoption.log"
+aggregate/convert_to_json nim "$TEST_OUT_DIR/nim" "$TEST_OUT_DIR/nim/ci.json"

--- a/config
+++ b/config
@@ -9,6 +9,7 @@ JAVA_TESTNG_JAR=$HOME/.m2/repository/org/testng/testng/6.9.10/testng-6.9.10.jar:
 JAVASCRIPT_RUNTIME_DIR=../runtime/javascript
 JAVASCRIPT_MODULES_DIR=node_modules
 LUA_RUNTIME_DIR=../runtime/lua
+NIM_RUNTIME_DIR=../runtime/nim
 PERL_RUNTIME_DIR=../runtime/perl/lib
 PYTHON_RUNTIME_DIR=../runtime/python
 RUBY_RUNTIME_DIR=../runtime/ruby/lib

--- a/run-nim
+++ b/run-nim
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 . ./config
 
@@ -16,11 +16,9 @@ fi
 rm -rf "$TEST_OUT_DIR/nim"
 mkdir -p "$TEST_OUT_DIR/nim/bin"
 
-i=0 args=()
+args=()
 for var in "$@"
 do
-	args[$i]="Kaitai Struct Compiler Test Suite::Nim: $var"
-	((++i))
+	args="$args \"Kaitai Struct Compiler Test Suite::Nim: $var\""
 done
-
-nim c -r --outdir:"$TEST_OUT_DIR/nim/bin" "spec/nim/test" "${args[@]}"
+eval nim c -r --outdir:"$TEST_OUT_DIR/nim/bin" "spec/nim/test" "$args"

--- a/run-nim
+++ b/run-nim
@@ -1,16 +1,16 @@
-#!/bin/sh
+#!/bin/bash
 
 . ./config
 
 if [ ! -f "spec/nim/test.nim" ]; then
-  RED='\033[1;31m'
-  YELLOW='\033[1;33m'
-  CYAN='\033[0;36m'
-  NC='\033[0m'
+	RED='\033[1;31m'
+	YELLOW='\033[1;33m'
+	CYAN='\033[0;36m'
+	NC='\033[0m'
 
-  printf "${RED}Error:${NC} Test suite doesn't exist\n"
-  printf "${YELLOW}Hint:${NC} Must first run the ${CYAN}run-nim_generate_suite${NC} script\n"
-  exit
+	printf "${RED}Error:${NC} Test suite doesn't exist\n"
+	printf "${YELLOW}Hint:${NC} Must first run the ${CYAN}run-nim_generate_suite${NC} script\n"
+	exit
 fi
 
 rm -rf "$TEST_OUT_DIR/nim"
@@ -19,9 +19,8 @@ mkdir -p "$TEST_OUT_DIR/nim/bin"
 i=0 args=()
 for var in "$@"
 do
-  args[$i]="Kaitai Struct Compiler Test Suite::Nim: $var"
-  ((++i))
+	args[$i]="Kaitai Struct Compiler Test Suite::Nim: $var"
+	((++i))
 done
 
-echo $arguments
 nim c -r --outdir:"$TEST_OUT_DIR/nim/bin" "spec/nim/test" "${args[@]}"

--- a/run-nim
+++ b/run-nim
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+. ./config
+
+if [ ! -f "spec/nim/test.nim" ]; then
+  RED='\033[1;31m'
+  YELLOW='\033[1;33m'
+  CYAN='\033[0;36m'
+  NC='\033[0m'
+
+  printf "${RED}Error:${NC} Test suite doesn't exist\n"
+  printf "${YELLOW}Hint:${NC} Must first run the ${CYAN}run-nim_generate_suite${NC} script\n"
+  exit
+fi
+
+rm -rf "$TEST_OUT_DIR/nim"
+mkdir -p "$TEST_OUT_DIR/nim/bin"
+
+i=0 args=()
+for var in "$@"
+do
+  args[$i]="Kaitai Struct Compiler Test Suite::Nim: $var"
+  ((++i))
+done
+
+echo $arguments
+nim c -r --outdir:"$TEST_OUT_DIR/nim/bin" "spec/nim/test" "${args[@]}"

--- a/run-nim_generate_suite
+++ b/run-nim_generate_suite
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+. ./config
+
+mkdir -p "$TEST_OUT_DIR/nim/bin"
+nim c -r --outdir:"$TEST_OUT_DIR/nim/bin" "spec/nim/generate_test_suite"

--- a/spec/nim/generate_test_suite.nim
+++ b/spec/nim/generate_test_suite.nim
@@ -1,0 +1,66 @@
+import os, strutils, sequtils, macros
+
+macro addCode(where, what: untyped): untyped =
+  result = newCall("add", where, toStrLit(what))
+
+template addImport(where, what: string) =
+  where.add("import " & what & "\n")
+
+template addTest(where: untyped; name, code: string) =
+  where.add("  test \"" & name & "\":\n")
+  let linesOfCode = splitLines(code)
+  for l in linesOfCode:
+    where.add("    " & l & "\n")
+
+if paramCount() notin {0,1}:
+  echo "Wrong number of arguments"
+  quit QuitFailure
+
+var ci: bool
+
+if paramCount() == 1:
+  if paramStr(1) == "ci":
+    ci = true
+  else:
+    echo "The only valid argument is 'ci'"
+    quit QuitFailure
+
+setCurrentDir("spec/nim")
+
+var
+  code: string
+  names = newSeq[string]()
+  tests = newSeq[string]()
+  imports = newSeq[string]()
+
+for _, name in walkDir("tests", true):
+  names.add("Nim: " & name[1..^5].split("_").mapIt(capitalizeAscii(it)).join)
+  tests.add(readFile("tests" / name))
+  imports.add(".." / ".." / "compiled" / "nim" / name[1..^5])
+
+addCode(code):
+  import unittest, "../../../runtime/nim/kaitai"
+
+if ci:
+  addCode(code):
+    import streams
+    var
+      stream = newFileStream("test_out/nim/report.xml", fmWrite)
+      outputFormatter = newJUnitOutputFormatter(stream)
+    addOutputFormatter(outputFormatter)
+
+code.add("\n\n")
+
+for i in imports:
+  code.addImport(i)
+
+code.add("\nsuite \"Kaitai Struct Compiler Test Suite\":\n")
+
+for (name, test) in zip(names, tests):
+  code.addTest(name, test)
+
+if ci:
+  addCode(code):
+    close(outputFormatter)
+
+writeFile("test.nim", strip(code))

--- a/spec/nim/tdefault_big_endian.nim
+++ b/spec/nim/tdefault_big_endian.nim
@@ -1,0 +1,8 @@
+import unittest
+import ../../../runtime/nim/kaitai
+import ../../compiled/nim/default_big_endian
+
+suite "Default big endian":
+  test "Value read":
+    let value = DefaultBigEndian.read("../../src/enum_0.bin")
+    check(value.one == 117440512)

--- a/spec/nim/tdefault_big_endian.nim
+++ b/spec/nim/tdefault_big_endian.nim
@@ -1,8 +1,0 @@
-import unittest
-import ../../../runtime/nim/kaitai
-import ../../compiled/nim/default_big_endian
-
-suite "Default big endian":
-  test "Value read":
-    let value = DefaultBigEndian.fromFile("src/enum_0.bin")
-    check(value.one == 117440512)

--- a/spec/nim/tdefault_big_endian.nim
+++ b/spec/nim/tdefault_big_endian.nim
@@ -4,5 +4,5 @@ import ../../compiled/nim/default_big_endian
 
 suite "Default big endian":
   test "Value read":
-    let value = DefaultBigEndian.read("../../src/enum_0.bin")
+    let value = DefaultBigEndian.fromFile("src/enum_0.bin")
     check(value.one == 117440512)

--- a/spec/nim/tests/tdefault_big_endian.nim
+++ b/spec/nim/tests/tdefault_big_endian.nim
@@ -1,0 +1,2 @@
+let value = DefaultBigEndian.fromFile("src/enum_0.bin")
+check(value.one == 117440512)


### PR DESCRIPTION
`ci-nim` produces a correct `ci.json` in `$TEST_OUT_DIR/nim`.
This PR goes together with [this one](https://github.com/kaitai-io/kaitai_struct_compiler/pull/170).
Can we merge both so I can proceed with setting up Nim for Travis in [ci_targets repo](https://github.com/kaitai-io/ci_targets)?