### PR TITLE
Add tests for EOS exceptions

### DIFF
--- a/formats/eos_exception_bytes.ksy
+++ b/formats/eos_exception_bytes.ksy
@@ -1,0 +1,11 @@
+meta:
+  id: eos_exception_bytes
+seq:
+  - id: envelope
+    type: data
+    size: 6
+types:
+  data:
+    seq:
+      - id: buf
+        size: 7

--- a/formats/eos_exception_u4.ksy
+++ b/formats/eos_exception_u4.ksy
@@ -1,0 +1,13 @@
+meta:
+  id: eos_exception_u4
+seq:
+  - id: envelope
+    type: data
+    size: 6
+types:
+  data:
+    seq:
+      - id: prebuf
+        size: 3
+      - id: fail_int
+        type: u4le

--- a/spec/cpp_stl_11/test_eos_exception_bytes.cpp
+++ b/spec/cpp_stl_11/test_eos_exception_bytes.cpp
@@ -1,0 +1,17 @@
+#include <boost/test/unit_test.hpp>
+
+#include <eos_exception_bytes.h>
+
+#include <iostream>
+#include <fstream>
+#include <vector>
+
+BOOST_AUTO_TEST_CASE(test_eos_exception_bytes) {
+    std::ifstream ifs("src/term_strz.bin", std::ifstream::binary);
+    kaitai::kstream ks(&ifs);
+
+    BOOST_CHECK_THROW(
+        eos_exception_bytes_t* r = new eos_exception_bytes_t(&ks),
+        std::ifstream::failure
+    );
+}

--- a/spec/cpp_stl_11/test_eos_exception_u4.cpp
+++ b/spec/cpp_stl_11/test_eos_exception_u4.cpp
@@ -1,0 +1,17 @@
+#include <boost/test/unit_test.hpp>
+
+#include <eos_exception_u4.h>
+
+#include <iostream>
+#include <fstream>
+#include <vector>
+
+BOOST_AUTO_TEST_CASE(test_eos_exception_u4) {
+    std::ifstream ifs("src/term_strz.bin", std::ifstream::binary);
+    kaitai::kstream ks(&ifs);
+
+    BOOST_CHECK_THROW(
+        eos_exception_u4_t* r = new eos_exception_u4_t(&ks),
+        std::ifstream::failure
+    );
+}

--- a/spec/cpp_stl_98/test_eos_exception_bytes.cpp
+++ b/spec/cpp_stl_98/test_eos_exception_bytes.cpp
@@ -1,0 +1,17 @@
+#include <boost/test/unit_test.hpp>
+
+#include <eos_exception_bytes.h>
+
+#include <iostream>
+#include <fstream>
+#include <vector>
+
+BOOST_AUTO_TEST_CASE(test_eos_exception_bytes) {
+    std::ifstream ifs("src/term_strz.bin", std::ifstream::binary);
+    kaitai::kstream ks(&ifs);
+
+    BOOST_CHECK_THROW(
+        eos_exception_bytes_t* r = new eos_exception_bytes_t(&ks),
+        std::ifstream::failure
+    );
+}

--- a/spec/cpp_stl_98/test_eos_exception_u4.cpp
+++ b/spec/cpp_stl_98/test_eos_exception_u4.cpp
@@ -1,0 +1,17 @@
+#include <boost/test/unit_test.hpp>
+
+#include <eos_exception_u4.h>
+
+#include <iostream>
+#include <fstream>
+#include <vector>
+
+BOOST_AUTO_TEST_CASE(test_eos_exception_u4) {
+    std::ifstream ifs("src/term_strz.bin", std::ifstream::binary);
+    kaitai::kstream ks(&ifs);
+
+    BOOST_CHECK_THROW(
+        eos_exception_u4_t* r = new eos_exception_u4_t(&ks),
+        std::ifstream::failure
+    );
+}

--- a/spec/csharp/kaitai_struct_csharp_tests/tests/SpecEosExceptionBytes.cs
+++ b/spec/csharp/kaitai_struct_csharp_tests/tests/SpecEosExceptionBytes.cs
@@ -1,0 +1,21 @@
+using System;
+using System.IO;
+
+namespace Kaitai
+{
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class SpecEosExceptionBytes : CommonSpec
+    {
+        [Test]
+        public void TestEosExceptionBytes()
+        {
+            Assert.Throws<EndOfStreamException>(
+                delegate {
+                    EosExceptionBytes.FromFile(SourceFile("term_strz.bin"));
+                }
+            );
+        }
+    }
+}

--- a/spec/csharp/kaitai_struct_csharp_tests/tests/SpecEosExceptionU4.cs
+++ b/spec/csharp/kaitai_struct_csharp_tests/tests/SpecEosExceptionU4.cs
@@ -1,0 +1,19 @@
+using NUnit.Framework;
+using System.IO;
+
+namespace Kaitai
+{
+    [TestFixture]
+    public class SpecEosExceptionU4 : CommonSpec
+    {
+        [Test]
+        public void TestEosExceptionU4()
+        {
+            Assert.Throws<EndOfStreamException>(
+                delegate {
+                    EosExceptionU4.FromFile(SourceFile("term_strz.bin"));
+                }
+            );
+        }
+    }
+}

--- a/spec/java/src/io/kaitai/struct/spec/TestEosExceptionBytes.java
+++ b/spec/java/src/io/kaitai/struct/spec/TestEosExceptionBytes.java
@@ -1,0 +1,17 @@
+package io.kaitai.struct.spec;
+
+import io.kaitai.struct.testformats.EosExceptionBytes;
+import io.kaitai.struct.testformats.StrEncodings;
+import org.testng.annotations.Test;
+
+import java.nio.BufferUnderflowException;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+
+public class TestEosExceptionBytes extends CommonSpec {
+    @Test(expectedExceptions = BufferUnderflowException.class)
+    public void testEosExceptionBytes() throws Exception {
+        EosExceptionBytes r = EosExceptionBytes.fromFile(SRC_DIR + "term_strz.bin");
+    }
+}

--- a/spec/java/src/io/kaitai/struct/spec/TestEosExceptionU4.java
+++ b/spec/java/src/io/kaitai/struct/spec/TestEosExceptionU4.java
@@ -1,0 +1,15 @@
+package io.kaitai.struct.spec;
+
+import io.kaitai.struct.testformats.EosExceptionU4;
+import org.testng.annotations.Test;
+
+import java.nio.BufferUnderflowException;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestEosExceptionU4 extends CommonSpec {
+    @Test(expectedExceptions = BufferUnderflowException.class)
+    public void testEosExceptionU4() throws Exception {
+        EosExceptionU4 r = EosExceptionU4.fromFile(SRC_DIR + "term_strz.bin");
+    }
+}

--- a/spec/javascript/test_eos_exception_bytes.js
+++ b/spec/javascript/test_eos_exception_bytes.js
@@ -1,0 +1,4 @@
+var testHelperThrows = require('testHelperThrows');
+var KaitaiStream = require('kaitai-struct/KaitaiStream');
+
+testHelperThrows('EosExceptionBytes', 'src/term_strz.bin', KaitaiStream.EOFError);

--- a/spec/javascript/test_eos_exception_u4.js
+++ b/spec/javascript/test_eos_exception_u4.js
@@ -1,0 +1,4 @@
+var testHelperThrows = require('testHelperThrows');
+
+// TODO: may be this should throw KaitaiEOFError for uniformity?
+testHelperThrows('EosExceptionU4', 'src/term_strz.bin', RangeError);

--- a/spec/lua/test_eos_exception_bytes.lua
+++ b/spec/lua/test_eos_exception_bytes.lua
@@ -1,0 +1,9 @@
+local luaunit = require("luaunit")
+
+require("eos_exception_bytes")
+
+TestEosExceptionBytes = {}
+
+function TestEosExceptionBytes:test_eos_exception_bytes()
+    luaunit.assertError(EosExceptionBytes.from_file, "src/term_strz.bin")
+end

--- a/spec/lua/test_eos_exception_u4.lua
+++ b/spec/lua/test_eos_exception_u4.lua
@@ -1,0 +1,9 @@
+local luaunit = require("luaunit")
+
+require("eos_exception_u4")
+
+TestEosExceptionU4 = {}
+
+function TestEosExceptionU4:test_eos_exception_u4()
+    luaunit.assertError(EosExceptionU4.from_file, "src/term_strz.bin")
+end

--- a/spec/perl/TestEosExceptionBytes.t
+++ b/spec/perl/TestEosExceptionBytes.t
@@ -1,0 +1,14 @@
+package spec::perl::TestEosExceptionBytes;
+
+use strict;
+use warnings;
+use base qw(Test::Class);
+use Test::More;
+use EosExceptionBytes;
+use Test::Exception;
+
+sub test_eos_exception_bytes: Test(1) {
+    dies_ok { EosExceptionBytes->from_file('src/term_strz.bin') } 'Died';
+}
+
+Test::Class->runtests;

--- a/spec/perl/TestEosExceptionU4.t
+++ b/spec/perl/TestEosExceptionU4.t
@@ -1,0 +1,14 @@
+package spec::perl::TestEosExceptionU4;
+
+use strict;
+use warnings;
+use base qw(Test::Class);
+use Test::More;
+use EosExceptionU4;
+use Test::Exception;
+
+sub test_eos_exception_u4: Test(1) {
+    dies_ok { EosExceptionU4->from_file('src/term_strz.bin') } 'Died';
+}
+
+Test::Class->runtests;

--- a/spec/php/EosExceptionBytesTest.php
+++ b/spec/php/EosExceptionBytesTest.php
@@ -1,0 +1,12 @@
+<?php
+namespace Kaitai\Struct\Tests;
+
+class EosExceptionBytesTest extends TestCase {
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Requested 13 bytes, but got only 12 bytes
+     */
+    public function testEosExceptionBytes() {
+        EosExceptionBytes::fromFile(self::SRC_DIR_PATH . "/term_strz.bin");
+    }
+}

--- a/spec/php/EosExceptionU4Test.php
+++ b/spec/php/EosExceptionU4Test.php
@@ -1,0 +1,12 @@
+<?php
+namespace Kaitai\Struct\Tests;
+
+class EosExceptionU4Test extends TestCase {
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Requested 4 bytes, but got only 3 bytes
+     */
+    public function testEosExceptionU4() {
+        EosExceptionU4::fromFile(self::SRC_DIR_PATH . "/term_strz.bin");
+    }
+}

--- a/spec/python/test_eos_exception_bytes.py
+++ b/spec/python/test_eos_exception_bytes.py
@@ -1,0 +1,9 @@
+import unittest
+
+from eos_exception_bytes import EosExceptionBytes
+
+class TestEosExceptionBytes(unittest.TestCase):
+    def test_eos_exception_bytes(self):
+        with self.assertRaises(EOFError):
+            with EosExceptionBytes.from_file("src/term_strz.bin"):
+                pass

--- a/spec/python/test_eos_exception_u4.py
+++ b/spec/python/test_eos_exception_u4.py
@@ -1,0 +1,9 @@
+import unittest
+
+from eos_exception_u4 import EosExceptionU4
+
+class TestEosExceptionU4(unittest.TestCase):
+    def test_eos_exception_u4(self):
+        with self.assertRaises(EOFError):
+            with EosExceptionU4.from_file("src/term_strz.bin"):
+                pass

--- a/spec/ruby/eos_exception_bytes_spec.rb
+++ b/spec/ruby/eos_exception_bytes_spec.rb
@@ -1,0 +1,9 @@
+require 'eos_exception_bytes'
+
+RSpec.describe EosExceptionBytes do
+  it 'parses test properly' do
+    expect {
+      r = EosExceptionBytes.from_file('src/term_strz.bin')
+    }.to raise_error(EOFError)
+  end
+end

--- a/spec/ruby/eos_exception_u4_spec.rb
+++ b/spec/ruby/eos_exception_u4_spec.rb
@@ -1,0 +1,9 @@
+require 'eos_exception_u4'
+
+RSpec.describe EosExceptionU4 do
+  it 'parses test properly' do
+    expect {
+      r = EosExceptionU4.from_file('src/term_strz.bin')
+    }.to raise_error(EOFError)
+  end
+end


### PR DESCRIPTION
I noticed that the JavaScript runtime does not throw an exception when trying to read beyond the end of substream, it just passes. This behavior can cause some errors which are hard to find.
So why not test it in all languages?