### PR TITLE
Make the builder more compatible with Windows.

### DIFF
--- a/builder/java_builder.rb
+++ b/builder/java_builder.rb
@@ -8,29 +8,37 @@ class JavaBuilder < PartialBuilder
   def initialize
     super
 
-    @spec_dir = 'spec/java/src'
-    @compiled_dir = "#{@config['FORMATS_COMPILED_DIR']}/java"
-    @project_file = "#{@compiled_dir}/src_list.txt"
+    @spec_dir     = File.join('spec', 'java', 'src')
+    @compiled_dir = File.join("#{@config['FORMATS_COMPILED_DIR']}", 'java')
+    @project_file = File.join("#{@compiled_dir}", 'src_list.txt')
 
     @java_runtime_dir = @config['JAVA_RUNTIME_DIR'] or raise "JAVA_RUNTIME_DIR is undefined"
+    @java_runtime_dir = File.absolute_path(@java_runtime_dir)
+
     @java_testng_jar = @config['JAVA_TESTNG_JAR'] or raise "JAVA_TESTNG_JAR is undefined"
+    @java_testng_jar = @java_testng_jar.split(/(?<=\.jar):/).each { |x| File.absolute_path(x) }
+    @java_testng_jar = @java_testng_jar.join(File::PATH_SEPARATOR)
 
     @java_classes_dir = "#{@compiled_dir}/bin"
+    @java_classes_dir = File.absolute_path(@java_classes_dir)
+    @java_classpath   = [@java_classes_dir, @java_testng_jar].join(File::PATH_SEPARATOR)
 
     @test_out_dir = "#{@config['TEST_OUT_DIR']}/java"
+    @test_out_dir = File.absolute_path(@test_out_dir)
   end
 
   def list_mandatory_files
-    Dir.glob("#{@java_runtime_dir}/src/main/**/*.java")
+    Dir.glob(File.join("#{@java_runtime_dir}", 'src', 'main', '**/*.java'))
   end
 
   def list_disposable_files
-    Dir.glob("#{@spec_dir}/**/*.java") + Dir.glob("#{@compiled_dir}/src/**/*.java")
+    Dir.glob(File.join("#{@spec_dir}", '**/*.java')) +
+    Dir.glob(File.join("#{@compiled_dir}", 'src', '**/*.java'))
   end
 
   def create_project(mand_files, disp_files)
     File.open(@project_file, 'w') { |f|
-      (mand_files + disp_files).each { |l| f.puts l }
+      (mand_files + disp_files).each { |l| f.puts "\"#{l}\"" }
     }
     @project_file
   end
@@ -40,8 +48,8 @@ class JavaBuilder < PartialBuilder
     cli = [
       'javac',
       '-encoding', 'UTF-8',
-      '-cp', "#{@java_classes_dir}:#{@java_testng_jar}",
-      '-d', @java_classes_dir,
+      '-cp',  @java_classpath,
+      '-d',   @java_classes_dir,
       "@#{@project_file}",
     ]
     run_and_tee({}, cli, log_file).exitstatus
@@ -78,22 +86,22 @@ class JavaBuilder < PartialBuilder
   def run_tests
     orig_dir = Dir.pwd
     FileUtils.mkdir_p(@test_out_dir)
-    FileUtils.rm_rf("#{@test_out_dir}/junitreports")
+    FileUtils.rm_rf(File.join("#{@test_out_dir}", 'junitreports'))
 
     cli = [
       'java',
-      '-cp', "#{File.absolute_path(@java_classes_dir)}:#{File.absolute_path(@java_testng_jar)}",
+      '-cp', @java_classpath,
       'org.testng.TestNG',
-      '-d', "#{File.absolute_path(@test_out_dir)}", File.absolute_path('spec/java/testng.xml')
+      '-d', @test_out_dir, File.absolute_path(File.join('spec', 'java', 'testng.xml'))
     ]
-    out_log = "#{File.absolute_path(@test_out_dir)}/test_run.stdout"
+    out_log = File.join(@test_out_dir, 'test_run.stdout')
 
     # Java uses "../../src" to locate binary input files, so we change
     # working directory prior to running tests to match that
-    Dir.chdir('spec/java')
+    Dir.chdir(File.join('spec', 'java'))
     run_and_tee({}, cli, out_log)
     Dir.chdir(orig_dir)
 
-    File.exists?("#{@test_out_dir}/junitreports")
+    File.exists?(File.join(@test_out_dir, 'junitreports'))
   end
 end


### PR DESCRIPTION
During testing updated PRs https://github.com/kaitai-io/kaitai_struct_compiler/pull/160 and https://github.com/kaitai-io/kaitai_struct_tests/pull/51 I recognized build errors related to hard-coded command lines and stuff like that. Changed that to OS-abstraction provided by ruby and the tests execute now.

Various things needed to be changed:

* ":" -> ";" using FIlE::PATH_SEPERATOR
* "/" -> "\" using File.join because some paths simply got misinterpreted at some places
* quoting paths in "src_list.txt" to support paths containing spaces, as some printed paths were absolute and contain those for me.

While some tests till fail, I don't think this has to do with my changes:

	===============================================
	Kaitai Struct Java specs
	Total tests run: 167, Failures: 2, Skips: 0
	===============================================

	#### JavaBuilder: process_status: #<Process::Status: pid 9412 exit 1>
	#### JavaBuilder: running tests: elapsed: 2.14068s