### PR TITLE
Use TestContext.CurrentContext.TestDirectory as base directory path

### DIFF
--- a/spec/csharp/kaitai_struct_csharp_tests/CommonSpec.cs
+++ b/spec/csharp/kaitai_struct_csharp_tests/CommonSpec.cs
@@ -10,8 +10,7 @@ namespace Kaitai
             string testPath = Environment.GetEnvironmentVariable("CSHARP_TEST_SRC_PATH");
             if (testPath == null)
             {
-                char slash = Path.DirectorySeparatorChar;
-                testPath = ".." + slash + ".." + slash + ".." + slash + "src";
+                testPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "src");
             }
             return Path.Combine(testPath, filename);
         }


### PR DESCRIPTION
csproj copies src/* into $(TargetDir)/src so this should be stable location on all systems