### PR TITLE
Adjust ./ci-go to work on Windows, make various improvements

### DIFF
--- a/ci-go
+++ b/ci-go
@@ -2,11 +2,20 @@
 
 . ./config
 
-export GOPATH=$GOPATH:$(pwd)/compiled/go
+DIVIDER=":"
+CWD=$(pwd)
+
+if [ "$OS" = "Windows_NT" ]; then
+	DIVIDER=";"
+	# GOPATH needs the real Windows path, `pwd -W` should work (at least works for me in Git Bash for Windows (MSYS2 terminal))
+	CWD=$(pwd -W || pwd)
+fi
+
+export GOPATH="$CWD/compiled/go${DIVIDER}$GOPATH"
 
 # Symlink Go runtime libraries from full umbrella project checkout
 mkdir -p compiled/go/src/github.com/kaitai-io
-rm -f compiled/go/src/github.com/kaitai-io/kaitai_struct_go_runtime
+rm -rf compiled/go/src/github.com/kaitai-io/kaitai_struct_go_runtime
 ln -s ../../../../../../runtime/go compiled/go/src/github.com/kaitai-io/kaitai_struct_go_runtime
 
 ABS_TEST_OUT_DIR="$(pwd)/$TEST_OUT_DIR"
@@ -28,9 +37,9 @@ while [ "$keep_compiling" = 1 ]; do
 			echo "No recovery requested, bailing out"
 			exit 1
 		fi
-		if egrep "^\.\./\.\./compiled/go/.*:[0-9][0-9]*:" "$ABS_REPORT_LOG" >"$ABS_TEST_OUT_DIR/go/err.now"; then
+		if egrep "^\.\.[\\/]\.\.[\\/]compiled[\\/]go[\\/].*:[0-9][0-9]*:" "$ABS_REPORT_LOG" >"$ABS_TEST_OUT_DIR/go/err.now"; then
 			cat "$ABS_TEST_OUT_DIR/go/err.now" >>"$ABS_TEST_OUT_DIR/go/build.fails"
-			sed 's/:.*//' <"$ABS_TEST_OUT_DIR/go/err.now" | sort -u >"$ABS_TEST_OUT_DIR/go/to_delete.now"
+			sed -e 's/:.*//' -e 's/\\/\//g' <"$ABS_TEST_OUT_DIR/go/err.now" | sort -u >"$ABS_TEST_OUT_DIR/go/to_delete.now"
 			xargs rm <"$ABS_TEST_OUT_DIR/go/to_delete.now"
 			echo "Trying to recover, deleting..."
 			cat "$ABS_TEST_OUT_DIR/go/to_delete.now"


### PR DESCRIPTION
I'm using the MSYS2 terminal (more specifically, [Git Bash for Windows](https://gitforwindows.org/#bash)) for development, which is a Bash shell emulator. The problem is that when using Go for Windows, [the `GOPATH` environment variable](https://golang.org/doc/gopath_code.html#GOPATH) must be a Windows-like path (not `/c/kaitai_struct/tests/`, but `C:/kaitai_struct/tests/`). In the MSYS2 terminal I use, the output of `pwd --help` command hints me that I can use `-W` option to get the Windows physical directory rather than the virtual unix-like path. Here's the output:

```
$ pwd --help
pwd: pwd [-LPW]
    Print the name of the current working directory.

    Options:
      -L        print the value of $PWD if it names the current working
                directory
      -P        print the physical directory, without any symbolic links
      -W        print the Win32 value of the physical directory

    By default, `pwd' behaves as if `-L' were specified.

    Exit Status:
    Returns 0 unless an invalid option is given or the current directory
    cannot be read.
```

Unfortunately, I have no idea if `pwd -W` works in other shells that can be run on Windows. If you know a more reliable way how to get the physical path, please share it.

I also insert the `$(pwd)/compiled/go` directory to the **beginning** of `GOPATH`, not to the end, because we want to prefer choosing this directory over any existing folder in `GOPATH`. If there was some file in some of the `GOPATH` directories with the same name as some of our `.go` files in the test suite, we could have a problem otherwise. This little improvement is not limited Windows, and it's not required to work on Windows, it's just a general improvement of the script.

Then I noticed that the `rm` command doesn't have the `-r` (recursive) option, so it doesn't work for deleting directories:

```bash
Petr Pučil@DESKTOP-MKDR147 MINGW64 /d/temp/kaitai_struct/tests (ci-go-on-windows)
$ rm -f compiled/go/src/github.com/kaitai-io/kaitai_struct_go_runtime
rm: cannot remove 'compiled/go/src/github.com/kaitai-io/kaitai_struct_go_runtime': Is a directory
```

The last two changes are required for the build recovery to work on Windows, you have to convert the backslashes (in the paths from Go output) to forward slashes, because you obviously can't run `rm` with a path containing backslashes (or you can, but they'll disappear from the path. Without converting the slashes using `sed -e 's/\\/\//g'`, the output of `./ci-go` looks like this:

```
Petr Pučil@DESKTOP-MKDR147 MINGW64 /d/temp/kaitai_struct/tests (ci-go-on-windows)
$ ./ci-go 
Got error:
# test_formats
..\..\compiled\go\src\test_formats\opaque_external_type_multi.go:8:6: undefined: Test1
..\..\compiled\go\src\test_formats\opaque_external_type_multi.go:9:6: undefined: Test2
..\..\compiled\go\src\test_formats\opaque_external_type_multi.go:10:6: undefined: Test3
..\..\compiled\go\src\test_formats\repeat_until_calc_array_type.go:46:7: no new variables on left side of :=
..\..\compiled\go\src\test_formats\repeat_until_sized.go:42:7: no new variables on left side of :=
FAIL    _/D_/temp/kaitai_struct/tests/spec/go [build failed]
FAIL
rm: cannot remove '....compiledgosrctest_formatsopaque_external_type_multi.go': No such file or directory
rm: cannot remove '....compiledgosrctest_formatsrepeat_until_calc_array_type.go': No such file or directory
rm: cannot remove '....compiledgosrctest_formatsrepeat_until_sized.go': No such file or directory
Trying to recover, deleting...
..\..\compiled\go\src\test_formats\opaque_external_type_multi.go
..\..\compiled\go\src\test_formats\repeat_until_calc_array_type.go
..\..\compiled\go\src\test_formats\repeat_until_sized.go
Got error:
# test_formats
..\..\compiled\go\src\test_formats\opaque_external_type_multi.go:8:6: undefined: Test1
..\..\compiled\go\src\test_formats\opaque_external_type_multi.go:9:6: undefined: Test2
..\..\compiled\go\src\test_formats\opaque_external_type_multi.go:10:6: undefined: Test3
..\..\compiled\go\src\test_formats\repeat_until_calc_array_type.go:46:7: no new variables on left side of :=
..\..\compiled\go\src\test_formats\repeat_until_sized.go:42:7: no new variables on left side of :=
FAIL    _/D_/temp/kaitai_struct/tests/spec/go [build failed]
FAIL
rm: cannot remove '....compiledgosrctest_formatsopaque_external_type_multi.go': No such file or directory
rm: cannot remove '....compiledgosrctest_formatsrepeat_until_calc_array_type.go': No such file or directory
rm: cannot remove '....compiledgosrctest_formatsrepeat_until_sized.go': No such file or directory
```

In short, it gets stuck in an infinite loop.

I'm using this modified script for around half a year, and it's working fine. I wouldn't be able to run Go tests without these changes, so I'm keeping them unstaged in the working directory (once I tried to mark the `./ci-go` file as `git update-index --assume-unchanged` to get rid of them in the area of modified files, but this doesn't go well when I checkout some older revision which makes some changes to this file, because Git heartlessly rewrites them and the changes are lost). I couldn't push myself to make a PR for them until now 😃

So I doubt if I actually help somebody with these changes, but at least I'll feel better as I get rid of one stale file in the `Changes not staged for commit` section.