### PR TITLE
fixed reading junit xml reports with invalid UTF-8 sequences

### DIFF
--- a/aggregate/junit_xml_parser.rb
+++ b/aggregate/junit_xml_parser.rb
@@ -8,10 +8,10 @@ class JUnitXMLParser < TestParser
       []
     elsif File.directory?(fn)
       Dir.glob("#{fn}/*.xml").map { |x|
-        REXML::Document.new(File.read(x))
+        REXML::Document.new(File.read(x).encode('UTF-8', :invalid=>:replace, :replace=>"?"))
       }
     else
-      [REXML::Document.new(File.read(fn))]
+      [REXML::Document.new(File.read(fn).encode('UTF-8', :invalid=>:replace, :replace=>"?"))]
     end
   end
 


### PR DESCRIPTION
currently ci-lua produces invalid bytes under some tests, and reports do not get parsed.
this fixes the issue by replacing the incorrect UTF-8 byte sequences by `?` chars
since those are only in test outputs, it should be acceptable