### PR TITLE
Normalize node paths in errors (for compiler#229)

### DIFF
--- a/formats_err/enum_ref_unknown.ksy
+++ b/formats_err/enum_ref_unknown.ksy
@@ -1,4 +1,4 @@
-# enum_ref_unknown.ksy: /seq/0:
+# enum_ref_unknown.ksy: /seq/0/enum:
 # 	error: unable to find enum 'animal', searching from enum_ref_unknown
 #
 meta:

--- a/formats_err/expr_inst_value_broken.ksy
+++ b/formats_err/expr_inst_value_broken.ksy
@@ -1,4 +1,4 @@
-# expr_inst_value_broken.ksy: /instances/foo:
+# expr_inst_value_broken.ksy: /instances/foo/value:
 # 	error: parsing expression '1 *' failed on 1:3, expected "or" | CharsWhile(Set( , n)) | "\\\n" | End
 #
 meta:

--- a/formats_err/expr_unbalanced.ksy
+++ b/formats_err/expr_unbalanced.ksy
@@ -1,4 +1,4 @@
-# expr_unbalanced.ksy: /seq/0:
+# expr_unbalanced.ksy: /seq/0/size:
 # 	error: parsing expression '(1 + 5' failed on 1:1, expected "not" ~ !(namePart) ~ not_test | comparison
 #
 meta:

--- a/formats_err/expr_wrong_and.ksy
+++ b/formats_err/expr_wrong_and.ksy
@@ -1,4 +1,4 @@
-# expr_wrong_and.ksy: /instances/both:
+# expr_wrong_and.ksy: /instances/both/value:
 # 	error: parsing expression 'foo == 1 && bar == 2' failed on 1:10, expected "or" | CharsWhile(Set( , n)) | "\\\n" | End, did you mean 'and'?
 #
 meta:

--- a/formats_err/meta_imports_abs_unknown.ksy
+++ b/formats_err/meta_imports_abs_unknown.ksy
@@ -1,5 +1,5 @@
 # meta_imports_abs_unknown.ksy: /meta/imports/0:
-# 	error: Unable to find 'unknown_absolute_name' in import search paths, using: List()
+# 	error: unable to find 'unknown_absolute_name.ksy' in import search paths, using: List()
 #
 meta:
   id: meta_imports_abs_unknown

--- a/formats_err/meta_no_id.ksy
+++ b/formats_err/meta_no_id.ksy
@@ -1,4 +1,4 @@
-# meta_no_id.ksy: /meta/id:
+# meta_no_id.ksy: /meta:
 # 	error: no `meta/id` encountered in top-level class spec
 #
 meta:

--- a/formats_err/params_call_malformed.ksy
+++ b/formats_err/params_call_malformed.ksy
@@ -1,4 +1,4 @@
-# params_call_malformed.ksy: /seq/0:
+# params_call_malformed.ksy: /seq/0/type:
 # 	error: parsing expression '2 + 3, ' failed on 1:6, expected CharsWhile(Set( , n)) | "\\\n" | End
 #
 meta:

--- a/formats_err/params_def_unknown_type.ksy
+++ b/formats_err/params_def_unknown_type.ksy
@@ -1,4 +1,4 @@
-# params_def_unknown_type.ksy: /params/0:
+# params_def_unknown_type.ksy: /params/0/type:
 # 	error: unable to find type 'bar', searching from params_def_unknown_type
 #
 meta:

--- a/formats_err/switch_cases_array.ksy
+++ b/formats_err/switch_cases_array.ksy
@@ -1,4 +1,4 @@
-# switch_cases_array.ksy: /seq/0/cases:
+# switch_cases_array.ksy: /seq/0/type/cases:
 # 	error: expected string, got [1, 2, 3] (class java.util.ArrayList)
 #
 meta:

--- a/formats_err/switch_cases_invalid.ksy
+++ b/formats_err/switch_cases_invalid.ksy
@@ -1,4 +1,4 @@
-# switch_cases_invalid.ksy: /seq/0/cases:
+# switch_cases_invalid.ksy: /seq/0/type/cases:
 # 	error: expected map, got foo (class java.lang.String)
 #
 meta:

--- a/formats_err/switch_cases_malformed_quoting.ksy
+++ b/formats_err/switch_cases_malformed_quoting.ksy
@@ -1,4 +1,4 @@
-# switch_cases_malformed_quoting.ksy: /seq/1/cases/^AHEM:
+# switch_cases_malformed_quoting.ksy: /seq/1/type/cases/^AHEM:
 # 	error: parsing expression '^AHEM' failed on 1:1, expected "not" ~ !(namePart) ~ not_test | comparison
 #
 meta:

--- a/formats_err/switch_invalid_key.ksy
+++ b/formats_err/switch_invalid_key.ksy
@@ -1,4 +1,4 @@
-# switch_invalid_key.ksy: /seq/0/bar:
+# switch_invalid_key.ksy: /seq/0/type/bar:
 # 	error: unknown key found, expected: cases, switch-on
 #
 meta:

--- a/formats_err/switch_no_cases.ksy
+++ b/formats_err/switch_no_cases.ksy
@@ -1,4 +1,4 @@
-# switch_no_cases.ksy: /seq/0/cases:
+# switch_no_cases.ksy: /seq/0:
 # 	error: missing mandatory argument `cases`
 #
 meta:

--- a/formats_err/switch_no_cases.ksy
+++ b/formats_err/switch_no_cases.ksy
@@ -1,4 +1,4 @@
-# switch_no_cases.ksy: /seq/0:
+# switch_no_cases.ksy: /seq/0/type:
 # 	error: missing mandatory argument `cases`
 #
 meta:

--- a/formats_err/switch_no_switch_on.ksy
+++ b/formats_err/switch_no_switch_on.ksy
@@ -1,4 +1,4 @@
-# switch_no_switch_on.ksy: /seq/0:
+# switch_no_switch_on.ksy: /seq/0/type:
 # 	error: missing mandatory argument `switch-on`
 #
 meta:

--- a/formats_err/switch_no_switch_on.ksy
+++ b/formats_err/switch_no_switch_on.ksy
@@ -1,4 +1,4 @@
-# switch_no_switch_on.ksy: /seq/0/switch-on:
+# switch_no_switch_on.ksy: /seq/0:
 # 	error: missing mandatory argument `switch-on`
 #
 meta:

--- a/formats_err/switch_on_malformed.ksy
+++ b/formats_err/switch_on_malformed.ksy
@@ -1,4 +1,4 @@
-# switch_on_malformed.ksy: /seq/0/switch-on:
+# switch_on_malformed.ksy: /seq/0/type/switch-on:
 # 	error: parsing expression '42/' failed on 1:3, expected "or" | CharsWhile(Set( , n)) | "\\\n" | End
 #
 meta:

--- a/formats_err/type_unknown.ksy
+++ b/formats_err/type_unknown.ksy
@@ -1,4 +1,4 @@
-# type_unknown.ksy: /seq/0:
+# type_unknown.ksy: /seq/0/type:
 # 	error: unable to find type 'some_unknown_name', searching from type_unknown
 #
 meta:


### PR DESCRIPTION
After this change all paths in errors will point to existing nodes in KSY file and node, where error is originated

This PR should be merged together with https://github.com/kaitai-io/kaitai_struct_compiler/pull/229 where actual fix done