### PR TITLE
Adapt to JS generated code exporting an object (not a function)

### DIFF
--- a/helpers/javascript/CustomFxNoArgs.js
+++ b/helpers/javascript/CustomFxNoArgs.js
@@ -1,14 +1,14 @@
-// This is a generated file! Please edit source .ksy file and use kaitai-struct-compiler to rebuild
+'use strict';
 
 (function (root, factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['kaitai-struct/KaitaiStream'], factory);
-  } else if (typeof module === 'object' && module.exports) {
-    module.exports = factory(require('kaitai-struct/KaitaiStream'));
+    define(['exports', 'kaitai-struct/KaitaiStream'], factory);
+  } else if (typeof exports === 'object' && exports !== null && typeof exports.nodeType !== 'number') {
+    factory(exports, require('kaitai-struct/KaitaiStream'));
   } else {
-    root.CustomFxNoArgs = factory(root.KaitaiStream);
+    factory(root.CustomFxNoArgs || (root.CustomFxNoArgs = {}), root.KaitaiStream);
   }
-}(this, function (KaitaiStream) {
+})(typeof self !== 'undefined' ? self : this, function (CustomFxNoArgs_, KaitaiStream) {
 var CustomFxNoArgs = (function() {
   function CustomFxNoArgs() {
   }
@@ -25,5 +25,5 @@ var CustomFxNoArgs = (function() {
 
   return CustomFxNoArgs;
 })();
-return CustomFxNoArgs;
-}));
+CustomFxNoArgs_.CustomFxNoArgs = CustomFxNoArgs;
+});

--- a/helpers/javascript/MyCustomFx.js
+++ b/helpers/javascript/MyCustomFx.js
@@ -1,14 +1,14 @@
-// This is a generated file! Please edit source .ksy file and use kaitai-struct-compiler to rebuild
+'use strict';
 
 (function (root, factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['kaitai-struct/KaitaiStream'], factory);
-  } else if (typeof module === 'object' && module.exports) {
-    module.exports = factory(require('kaitai-struct/KaitaiStream'));
+    define(['exports', 'kaitai-struct/KaitaiStream'], factory);
+  } else if (typeof exports === 'object' && exports !== null && typeof exports.nodeType !== 'number') {
+    factory(exports, require('kaitai-struct/KaitaiStream'));
   } else {
-    root.MyCustomFx = factory(root.KaitaiStream);
+    factory(root.MyCustomFx || (root.MyCustomFx = {}), root.KaitaiStream);
   }
-}(this, function (KaitaiStream) {
+})(typeof self !== 'undefined' ? self : this, function (MyCustomFx_, KaitaiStream) {
 var MyCustomFx = (function() {
   function MyCustomFx(key, flag, someBytes) {
     this.key = flag ? key : -key;
@@ -18,11 +18,11 @@ var MyCustomFx = (function() {
     var dest = new Uint8Array(len);
     for (var i = 0; i < len; i++) {
       dest[i] = src[i] + this.key;
-    }           
+    }
     return dest;
   }
 
   return MyCustomFx;
 })();
-return MyCustomFx;
-}));
+MyCustomFx_.MyCustomFx = MyCustomFx;
+});

--- a/helpers/javascript/nested-deeply/CustomFx.js
+++ b/helpers/javascript/nested-deeply/CustomFx.js
@@ -1,14 +1,14 @@
-// This is a generated file! Please edit source .ksy file and use kaitai-struct-compiler to rebuild
+'use strict';
 
 (function (root, factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['kaitai-struct/KaitaiStream'], factory);
-  } else if (typeof module === 'object' && module.exports) {
-    module.exports = factory(require('kaitai-struct/KaitaiStream'));
+    define(['exports', 'kaitai-struct/KaitaiStream'], factory);
+  } else if (typeof exports === 'object' && exports !== null && typeof exports.nodeType !== 'number') {
+    factory(exports, require('kaitai-struct/KaitaiStream'));
   } else {
-    root.CustomFx = factory(root.KaitaiStream);
+    factory(root.CustomFx || (root.CustomFx = {}), root.KaitaiStream);
   }
-}(this, function (KaitaiStream) {
+})(typeof self !== 'undefined' ? self : this, function (CustomFx_, KaitaiStream) {
 var CustomFx = (function() {
   function CustomFx(key) {
     this.key = key;
@@ -26,5 +26,5 @@ var CustomFx = (function() {
 
   return CustomFx;
 })();
-return CustomFx;
-}));
+CustomFx_.CustomFx = CustomFx;
+});

--- a/helpers/javascript/testHelper.js
+++ b/helpers/javascript/testHelper.js
@@ -4,7 +4,7 @@ function testHelper(className, fileName, testFunc) {
 
   describe(className, function() {
     it('parses test properly', function(done) {
-      var parser = require(className);
+      var parser = require(className)[className];
       fs.readFile(fileName, function(err, buf) {
         if (err) {
           done(err);

--- a/helpers/javascript/testHelperStream.js
+++ b/helpers/javascript/testHelperStream.js
@@ -4,7 +4,7 @@ function testHelperStream(className, fileName, testFunc) {
 
   describe(className, function() {
     it('parses test properly', function(done) {
-      var parser = require(className);
+      var parser = require(className)[className];
       fs.readFile(fileName, function(err, buf) {
         var st = new KaitaiStream(buf);
         testFunc(st, parser);

--- a/helpers/javascript/testHelperThrows.js
+++ b/helpers/javascript/testHelperThrows.js
@@ -6,7 +6,7 @@ function testHelperThrows(className, fileName, excClass) {
   describe(className, function() {
     it('parses test properly', function(done) {
       assert.ok(excClass);
-      var parser = require(className);
+      var parser = require(className)[className];
       fs.readFile(fileName, function(err, buf) {
         var st = new KaitaiStream(buf);
         assert.throws(


### PR DESCRIPTION
See https://github.com/kaitai-io/kaitai_struct/issues/1074

This is to adapt to the KSC changes from https://github.com/kaitai-io/kaitai_struct_compiler/pull/264. Therefore, this PR is marked as draft until the compiler PR is merged.