### PR TITLE
Fix order of expected warnings that was stabilized in compiler

### DIFF
--- a/formats_err/encoding_str_warnings.ksy
+++ b/formats_err/encoding_str_warnings.ksy
@@ -4,11 +4,11 @@
 # encoding_str_warnings.ksy: /seq/2/encoding:
 # 	warning: use canonical encoding name `ISO-8859-1` instead of `latin1` (see https://doc.kaitai.io/ksy_style_guide.html#encoding-name)
 #
-# encoding_str_warnings.ksy: /instances/wrong_case/encoding:
-# 	warning: use canonical encoding name `ISO-8859-1` instead of `iSo-8859-1` (see https://doc.kaitai.io/ksy_style_guide.html#encoding-name)
-#
 # encoding_str_warnings.ksy: /instances/alias/encoding:
 # 	warning: use canonical encoding name `ISO-8859-1` instead of `ISo8859-1` (see https://doc.kaitai.io/ksy_style_guide.html#encoding-name)
+#
+# encoding_str_warnings.ksy: /instances/wrong_case/encoding:
+# 	warning: use canonical encoding name `ISO-8859-1` instead of `iSo-8859-1` (see https://doc.kaitai.io/ksy_style_guide.html#encoding-name)
 #
 meta:
   id: encoding_str_warnings


### PR DESCRIPTION
Order was stabilized in https://github.com/kaitai-io/kaitai_struct_compiler/commit/5f561e194f40cf40942615bb5c63a2edfbd348ec

Fixes the following error:
```
[info] - encoding_str_warnings *** FAILED ***
[info]   encoding_str_warnings.ksy: /seq/1/encoding:
[info]   	warning: use canonical encoding name `UTF-8` instead of `utF-8` (see https://doc.kaitai.io/ksy_style_guide.html#encoding-name)
[info]   
[info]   encoding_str_warnings.ksy: /seq/2/encoding:
[info]   	warning: use canonical encoding name `ISO-8859-1` instead of `latin1` (see https://doc.kaitai.io/ksy_style_guide.html#encoding-name)
[info]   
[info]   encoding_str_warnings.ksy: /instances/alias/encoding:
[info]   	warning: use canonical encoding name `ISO-8859-1` instead of `ISo8859-1` (see https://doc.kaitai.io/ksy_style_guide.html#encoding-name)
[info]   
[info]   encoding_str_warnings.ksy: /instances/wrong_case/encoding:
[info]   	warning: use canonical encoding name `ISO-8859-1` instead of `iSo-8859-1` (see https://doc.kaitai.io/ksy_style_guide.html#encoding-name)
[info]    did not equal encoding_str_warnings.ksy: /seq/1/encoding:
[info]   	warning: use canonical encoding name `UTF-8` instead of `utF-8` (see https://doc.kaitai.io/ksy_style_guide.html#encoding-name)
[info]   
[info]   encoding_str_warnings.ksy: /seq/2/encoding:
[info]   	warning: use canonical encoding name `ISO-8859-1` instead of `latin1` (see https://doc.kaitai.io/ksy_style_guide.html#encoding-name)
[info]   
[info]   encoding_str_warnings.ksy: /instances/wrong_case/encoding:
[info]   	warning: use canonical encoding name `ISO-8859-1` instead of `iSo-8859-1` (see https://doc.kaitai.io/ksy_style_guide.html#encoding-name)
[info]   
[info]   encoding_str_warnings.ksy: /instances/alias/encoding:
[info]   	warning: use canonical encoding name `ISO-8859-1` instead of `ISo8859-1` (see https://doc.kaitai.io/ksy_style_guide.html#encoding-name) (SimpleMatchers.scala:34)
```

Closes https://github.com/kaitai-io/kaitai_struct/issues/1087.