### PR TITLE
Fix failed tests after compiler PR #269

### DIFF
--- a/formats_err/expr_bytes_to_s_arg0.ksy
+++ b/formats_err/expr_bytes_to_s_arg0.ksy
@@ -1,5 +1,5 @@
 # expr_bytes_to_s_arg0.ksy: /instances/bad/value:
-# 	error: to_s: expected 1 argument, got 0
+# 	error: wrong arguments to method call `to_s` on byte array: expected (string), got ()
 #
 meta:
   id: expr_bytes_to_s_arg0

--- a/formats_err/expr_bytes_to_s_arg2.ksy
+++ b/formats_err/expr_bytes_to_s_arg2.ksy
@@ -1,5 +1,5 @@
 # expr_bytes_to_s_arg2.ksy: /instances/bad/value:
-# 	error: to_s: expected 1 argument, got 2
+# 	error: wrong arguments to method call `to_s` on byte array: expected (string), got (Str(foo), Str(bar))
 #
 meta:
   id: expr_bytes_to_s_arg2

--- a/formats_err/expr_bytes_to_s_type.ksy
+++ b/formats_err/expr_bytes_to_s_type.ksy
@@ -1,5 +1,5 @@
 # expr_bytes_to_s_type.ksy: /instances/bad/value:
-# 	error: to_s: argument #0: expected string literal, got IntNum(123)
+# 	error: wrong arguments to method call `to_s` on byte array: expected (string), got (IntNum(123))
 #
 meta:
   id: expr_bytes_to_s_type


### PR DESCRIPTION
PR https://github.com/kaitai-io/kaitai_struct_compiler/pull/269 changes the error text, but tests was note updated. This PR fixes the tests.

Fixes

```
[info] - expr_bytes_to_s_arg0 *** FAILED ***
[info]   expr_bytes_to_s_arg0.ksy: /instances/bad/value:
[info]   	error: wrong arguments to method call `to_s` on byte array: expected (string), got ()
[info]    did not equal expr_bytes_to_s_arg0.ksy: /instances/bad/value:
[info]   	error: to_s: expected 1 argument, got 0 (SimpleMatchers.scala:34)
[info] - expr_bytes_to_s_arg2 *** FAILED ***
[info]   expr_bytes_to_s_arg2.ksy: /instances/bad/value:
[info]   	error: wrong arguments to method call `to_s` on byte array: expected (string), got (Str(foo), Str(bar))
[info]    did not equal expr_bytes_to_s_arg2.ksy: /instances/bad/value:
[info]   	error: to_s: expected 1 argument, got 2 (SimpleMatchers.scala:34)
[info] - expr_bytes_to_s_type *** FAILED ***
[info]   expr_bytes_to_s_type.ksy: /instances/bad/value:
[info]   	error: wrong arguments to method call `to_s` on byte array: expected (string), got (IntNum(123))
[info]    did not equal expr_bytes_to_s_type.ksy: /instances/bad/value:
[info]   	error: to_s: argument #0: expected string literal, got IntNum(123) (SimpleMatchers.scala:34)
```