### PR TITLE
C++/STL: recover from aborted tests

### DIFF
--- a/aggregate/boost_test_parser.rb
+++ b/aggregate/boost_test_parser.rb
@@ -46,4 +46,42 @@ class BoostTestParser < TestParser
       }
     }
   end
+
+  def aborted_tests
+    tests = []
+    # An "aborted" test means that "a critical error is detected", which means
+    # that "the test execution is aborted and all remaining tests are discarded"
+    # (see https://www.boost.org/doc/libs/1_84_0/libs/test/doc/html/boost/unit_test/test_observer.html#idm46380-bb).
+    # So in practice there will probably never be more than 1 aborted test (per
+    # log file), but we don't rely on that here and return an array anyway.
+    each_aborted_test { |t| tests << t }
+    tests
+  end
+
+  def each_aborted_test
+    r = @doc.root
+    r.elements.each('TestSuite/TestCase') { |tc|
+      next if tc.elements['Exception'].nil?
+
+      aborted = false
+
+      tc.elements.each('Message') { |msg|
+        next unless msg.text == 'Test is aborted'
+
+        file_attr = msg.attribute('file')
+        next if file_attr.nil?
+
+        file = file_attr.value
+        next unless file.end_with?('/boost/test/impl/unit_test_log.ipp')
+
+        aborted = true
+        break
+      }
+
+      next unless aborted
+
+      name = tc.attribute('name').value
+      yield name
+    }
+  end
 end

--- a/aggregate/convert_to_json
+++ b/aggregate/convert_to_json
@@ -66,7 +66,7 @@ result = case lang
 when 'cpp_stl'
   add_kst_adoption(
     add_fails(
-      BoostTestParser.new("#{infile}/results.xml").to_h,
+      BoostTestParser.new("#{infile}/results-*.xml", true).to_h,
       BuildFailedParser.new("#{infile}/build_failed_tests.txt").to_h,
       ValgrindXMLParser.new("#{infile}/valgrind.xml").to_h
     ),

--- a/builder/partial_builder.rb
+++ b/builder/partial_builder.rb
@@ -88,7 +88,7 @@ class PartialBuilder
       t2 = Time.now
       log "build attempt #{attempt_str}: elapsed: #{(t2 - t1).to_i}s"
       if result == 0
-        log attempt == 1 ? "perfect build succeeded" : "success on attempt \##{attempt_str}, #{disp_files.size}/#{orig_size} files survived"
+        log attempt == 1 ? "perfect build succeeded" : "success on build attempt #{attempt_str}, #{disp_files.size}/#{orig_size} files survived"
         return true
       else
         log "build failed"
@@ -104,7 +104,7 @@ class PartialBuilder
         attempt += 1
 
         if @max_attempts and attempt >= @max_attempts
-          log "maximum number of attempts reached, bailing out"
+          log "maximum number of build attempts reached, bailing out"
           return false
         end
       end

--- a/builder/spec/cpp/boost_aborted_gcc/test_out/cpp_stl_11/results.xml
+++ b/builder/spec/cpp/boost_aborted_gcc/test_out/cpp_stl_11/results.xml
@@ -1,0 +1,226 @@
+<TestLog>
+  <TestSuite name="C++/STL test units for Kaitai Struct">
+    <TestCase name="test_bcd_user_type_be" file="/tests/spec/cpp_stl_11/test_bcd_user_type_be.cpp" line="9">
+      <Info file="/tests/spec/cpp_stl_11/test_bcd_user_type_be.cpp" line="14"><![CDATA[check r->ltr()->as_int() == 12345678 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bcd_user_type_be.cpp" line="15"><![CDATA[check r->ltr()->as_str() == std::string("12345678") has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bcd_user_type_be.cpp" line="16"><![CDATA[check r->rtl()->as_int() == 87654321 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bcd_user_type_be.cpp" line="17"><![CDATA[check r->rtl()->as_str() == std::string("87654321") has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bcd_user_type_be.cpp" line="18"><![CDATA[check r->leading_zero_ltr()->as_int() == 123456 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bcd_user_type_be.cpp" line="19"><![CDATA[check r->leading_zero_ltr()->as_str() == std::string("00123456") has passed]]></Info>
+      <TestingTime>125</TestingTime>
+    </TestCase>
+    <TestCase name="test_bcd_user_type_le" file="/tests/spec/cpp_stl_11/test_bcd_user_type_le.cpp" line="9">
+      <Info file="/tests/spec/cpp_stl_11/test_bcd_user_type_le.cpp" line="14"><![CDATA[check r->ltr()->as_int() == 12345678 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bcd_user_type_le.cpp" line="15"><![CDATA[check r->ltr()->as_str() == std::string("12345678") has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bcd_user_type_le.cpp" line="16"><![CDATA[check r->rtl()->as_int() == 87654321 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bcd_user_type_le.cpp" line="17"><![CDATA[check r->rtl()->as_str() == std::string("87654321") has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bcd_user_type_le.cpp" line="18"><![CDATA[check r->leading_zero_ltr()->as_int() == 123456 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bcd_user_type_le.cpp" line="19"><![CDATA[check r->leading_zero_ltr()->as_str() == std::string("00123456") has passed]]></Info>
+      <TestingTime>102</TestingTime>
+    </TestCase>
+    <TestCase name="test_bits_byte_aligned" file="/tests/spec/cpp_stl_11/test_bits_byte_aligned.cpp" line="9">
+      <Info file="/tests/spec/cpp_stl_11/test_bits_byte_aligned.cpp" line="14"><![CDATA[check r->one() == 20 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_byte_aligned.cpp" line="15"><![CDATA[check r->byte_1() == 65 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_byte_aligned.cpp" line="16"><![CDATA[check r->two() == 2 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_byte_aligned.cpp" line="17"><![CDATA[check r->three() == false has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_byte_aligned.cpp" line="18"><![CDATA[check r->byte_2() == 75 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_byte_aligned.cpp" line="19"><![CDATA[check r->four() == 2892 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_byte_aligned.cpp" line="20"><![CDATA[check r->byte_3() == std::string("\xFF", 1) has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_byte_aligned.cpp" line="21"><![CDATA[check r->full_byte() == 255 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_byte_aligned.cpp" line="22"><![CDATA[check r->byte_4() == 80 has passed]]></Info>
+      <TestingTime>96</TestingTime>
+    </TestCase>
+    <TestCase name="test_bits_enum" file="/tests/spec/cpp_stl_11/test_bits_enum.cpp" line="9">
+      <Info file="/tests/spec/cpp_stl_11/test_bits_enum.cpp" line="14"><![CDATA[check r->one() == bits_enum_t::ANIMAL_PLATYPUS has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_enum.cpp" line="15"><![CDATA[check r->two() == bits_enum_t::ANIMAL_HORSE has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_enum.cpp" line="16"><![CDATA[check r->three() == bits_enum_t::ANIMAL_CAT has passed]]></Info>
+      <TestingTime>77</TestingTime>
+    </TestCase>
+    <TestCase name="test_bits_seq_endian_combo" file="/tests/spec/cpp_stl_11/test_bits_seq_endian_combo.cpp" line="9">
+      <Info file="/tests/spec/cpp_stl_11/test_bits_seq_endian_combo.cpp" line="14"><![CDATA[check r->be1() == 59 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_seq_endian_combo.cpp" line="15"><![CDATA[check r->be2() == 187 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_seq_endian_combo.cpp" line="16"><![CDATA[check r->le3() == 163 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_seq_endian_combo.cpp" line="17"><![CDATA[check r->be4() == 20 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_seq_endian_combo.cpp" line="18"><![CDATA[check r->le5() == 10 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_seq_endian_combo.cpp" line="19"><![CDATA[check r->le6() == 36 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_seq_endian_combo.cpp" line="20"><![CDATA[check r->le7() == 26 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_seq_endian_combo.cpp" line="21"><![CDATA[check r->be8() == true has passed]]></Info>
+      <TestingTime>88</TestingTime>
+    </TestCase>
+    <TestCase name="test_bits_shift_by_b32_le" file="/tests/spec/cpp_stl_11/test_bits_shift_by_b32_le.cpp" line="9">
+      <Info file="/tests/spec/cpp_stl_11/test_bits_shift_by_b32_le.cpp" line="14"><![CDATA[check r->a() == 4294967295UL has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_shift_by_b32_le.cpp" line="15"><![CDATA[check r->b() == 0 has passed]]></Info>
+      <TestingTime>78</TestingTime>
+    </TestCase>
+    <TestCase name="test_bits_shift_by_b64_le" file="/tests/spec/cpp_stl_11/test_bits_shift_by_b64_le.cpp" line="9">
+      <Info file="/tests/spec/cpp_stl_11/test_bits_shift_by_b64_le.cpp" line="14"><![CDATA[check r->a() == 18446744073709551615ULL has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_shift_by_b64_le.cpp" line="15"><![CDATA[check r->b() == 0 has passed]]></Info>
+      <TestingTime>76</TestingTime>
+    </TestCase>
+    <TestCase name="test_bits_signed_res_b32_be" file="/tests/spec/cpp_stl_11/test_bits_signed_res_b32_be.cpp" line="9">
+      <Info file="/tests/spec/cpp_stl_11/test_bits_signed_res_b32_be.cpp" line="14"><![CDATA[check r->a() == 4294967295UL has passed]]></Info>
+      <TestingTime>71</TestingTime>
+    </TestCase>
+    <TestCase name="test_bits_signed_res_b32_le" file="/tests/spec/cpp_stl_11/test_bits_signed_res_b32_le.cpp" line="9">
+      <Info file="/tests/spec/cpp_stl_11/test_bits_signed_res_b32_le.cpp" line="14"><![CDATA[check r->a() == 4294967295UL has passed]]></Info>
+      <TestingTime>70</TestingTime>
+    </TestCase>
+    <TestCase name="test_bits_signed_shift_b32_le" file="/tests/spec/cpp_stl_11/test_bits_signed_shift_b32_le.cpp" line="9">
+      <Info file="/tests/spec/cpp_stl_11/test_bits_signed_shift_b32_le.cpp" line="14"><![CDATA[check r->a() == 0 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_signed_shift_b32_le.cpp" line="15"><![CDATA[check r->b() == 255 has passed]]></Info>
+      <TestingTime>75</TestingTime>
+    </TestCase>
+    <TestCase name="test_bits_signed_shift_b64_le" file="/tests/spec/cpp_stl_11/test_bits_signed_shift_b64_le.cpp" line="9">
+      <Info file="/tests/spec/cpp_stl_11/test_bits_signed_shift_b64_le.cpp" line="14"><![CDATA[check r->a() == 0 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_signed_shift_b64_le.cpp" line="15"><![CDATA[check r->b() == 255 has passed]]></Info>
+      <TestingTime>75</TestingTime>
+    </TestCase>
+    <TestCase name="test_bits_simple" file="/tests/spec/cpp_stl_11/test_bits_simple.cpp" line="9">
+      <Info file="/tests/spec/cpp_stl_11/test_bits_simple.cpp" line="14"><![CDATA[check r->byte_1() == 80 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_simple.cpp" line="15"><![CDATA[check r->byte_2() == 65 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_simple.cpp" line="16"><![CDATA[check r->bits_a() == false has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_simple.cpp" line="17"><![CDATA[check r->bits_b() == 4 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_simple.cpp" line="18"><![CDATA[check r->bits_c() == 3 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_simple.cpp" line="19"><![CDATA[check r->large_bits_1() == 300 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_simple.cpp" line="20"><![CDATA[check r->spacer() == 5 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_simple.cpp" line="21"><![CDATA[check r->large_bits_2() == 1329 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_simple.cpp" line="22"><![CDATA[check r->normal_s2() == -1 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_simple.cpp" line="23"><![CDATA[check r->byte_8_9_10() == 5259587 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_simple.cpp" line="24"><![CDATA[check r->byte_11_to_14() == 1261262125 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_simple.cpp" line="25"><![CDATA[check r->byte_15_to_19() == 293220057087LL has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_simple.cpp" line="26"><![CDATA[check r->byte_20_to_27() == 18446744073709551615ULL has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_simple.cpp" line="27"><![CDATA[check r->test_if_b1() == 123 has passed]]></Info>
+      <TestingTime>133</TestingTime>
+    </TestCase>
+    <TestCase name="test_bits_simple_le" file="/tests/spec/cpp_stl_11/test_bits_simple_le.cpp" line="9">
+      <Info file="/tests/spec/cpp_stl_11/test_bits_simple_le.cpp" line="14"><![CDATA[check r->byte_1() == 80 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_simple_le.cpp" line="15"><![CDATA[check r->byte_2() == 65 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_simple_le.cpp" line="16"><![CDATA[check r->bits_a() == true has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_simple_le.cpp" line="17"><![CDATA[check r->bits_b() == 1 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_simple_le.cpp" line="18"><![CDATA[check r->bits_c() == 4 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_simple_le.cpp" line="19"><![CDATA[check r->large_bits_1() == 331 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_simple_le.cpp" line="20"><![CDATA[check r->spacer() == 3 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_simple_le.cpp" line="21"><![CDATA[check r->large_bits_2() == 393 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_simple_le.cpp" line="22"><![CDATA[check r->normal_s2() == -1 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_simple_le.cpp" line="23"><![CDATA[check r->byte_8_9_10() == 4407632 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_simple_le.cpp" line="24"><![CDATA[check r->byte_11_to_14() == 760556875 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_simple_le.cpp" line="25"><![CDATA[check r->byte_15_to_19() == 1099499455812LL has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_simple_le.cpp" line="26"><![CDATA[check r->byte_20_to_27() == 18446744073709551615ULL has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_simple_le.cpp" line="27"><![CDATA[check r->test_if_b1() == 123 has passed]]></Info>
+      <TestingTime>99</TestingTime>
+    </TestCase>
+    <TestCase name="test_bits_unaligned_b32_be" file="/tests/spec/cpp_stl_11/test_bits_unaligned_b32_be.cpp" line="9">
+      <Info file="/tests/spec/cpp_stl_11/test_bits_unaligned_b32_be.cpp" line="14"><![CDATA[check r->a() == true has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_unaligned_b32_be.cpp" line="15"><![CDATA[check r->b() == 3648472617UL has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_unaligned_b32_be.cpp" line="16"><![CDATA[check r->c() == 10 has passed]]></Info>
+      <TestingTime>76</TestingTime>
+    </TestCase>
+    <TestCase name="test_bits_unaligned_b32_le" file="/tests/spec/cpp_stl_11/test_bits_unaligned_b32_le.cpp" line="9">
+      <Info file="/tests/spec/cpp_stl_11/test_bits_unaligned_b32_le.cpp" line="14"><![CDATA[check r->a() == false has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_unaligned_b32_le.cpp" line="15"><![CDATA[check r->b() == 173137398 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_unaligned_b32_le.cpp" line="16"><![CDATA[check r->c() == 69 has passed]]></Info>
+      <TestingTime>74</TestingTime>
+    </TestCase>
+    <TestCase name="test_bits_unaligned_b64_be" file="/tests/spec/cpp_stl_11/test_bits_unaligned_b64_be.cpp" line="9">
+      <Info file="/tests/spec/cpp_stl_11/test_bits_unaligned_b64_be.cpp" line="14"><![CDATA[check r->a() == true has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_unaligned_b64_be.cpp" line="15"><![CDATA[check r->b() == 15670070570729969769ULL has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_unaligned_b64_be.cpp" line="16"><![CDATA[check r->c() == 14 has passed]]></Info>
+      <TestingTime>74</TestingTime>
+    </TestCase>
+    <TestCase name="test_bits_unaligned_b64_le" file="/tests/spec/cpp_stl_11/test_bits_unaligned_b64_le.cpp" line="9">
+      <Info file="/tests/spec/cpp_stl_11/test_bits_unaligned_b64_le.cpp" line="14"><![CDATA[check r->a() == false has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_unaligned_b64_le.cpp" line="15"><![CDATA[check r->b() == 1902324737369038326LL has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bits_unaligned_b64_le.cpp" line="16"><![CDATA[check r->c() == 71 has passed]]></Info>
+      <TestingTime>74</TestingTime>
+    </TestCase>
+    <TestCase name="test_buffered_struct" file="/tests/spec/cpp_stl_11/test_buffered_struct.cpp" line="9">
+      <Info file="/tests/spec/cpp_stl_11/test_buffered_struct.cpp" line="14"><![CDATA[check r->len1() == 16 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_buffered_struct.cpp" line="15"><![CDATA[check r->block1()->number1() == 66 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_buffered_struct.cpp" line="16"><![CDATA[check r->block1()->number2() == 67 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_buffered_struct.cpp" line="17"><![CDATA[check r->len2() == 8 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_buffered_struct.cpp" line="18"><![CDATA[check r->block2()->number1() == 68 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_buffered_struct.cpp" line="19"><![CDATA[check r->block2()->number2() == 69 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_buffered_struct.cpp" line="20"><![CDATA[check r->finisher() == 238 has passed]]></Info>
+      <TestingTime>89</TestingTime>
+    </TestCase>
+    <TestCase name="test_bytes_pad_term" file="/tests/spec/cpp_stl_11/test_bytes_pad_term.cpp" line="9">
+      <Info file="/tests/spec/cpp_stl_11/test_bytes_pad_term.cpp" line="14"><![CDATA[check r->str_pad() == std::string("\x73\x74\x72\x31", 4) has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bytes_pad_term.cpp" line="15"><![CDATA[check r->str_term() == std::string("\x73\x74\x72\x32\x66\x6F\x6F", 7) has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bytes_pad_term.cpp" line="16"><![CDATA[check r->str_term_and_pad() == std::string("\x73\x74\x72\x2B\x2B\x2B\x33\x62\x61\x72\x2B\x2B\x2B", 13) has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_bytes_pad_term.cpp" line="17"><![CDATA[check r->str_term_include() == std::string("\x73\x74\x72\x34\x62\x61\x7A\x40", 8) has passed]]></Info>
+      <TestingTime>92</TestingTime>
+    </TestCase>
+    <TestCase name="test_cast_nested" file="/tests/spec/cpp_stl_11/test_cast_nested.cpp" line="9">
+      <Info file="/tests/spec/cpp_stl_11/test_cast_nested.cpp" line="14"><![CDATA[check r->opcodes_0_str()->value() == std::string("foobar") has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_cast_nested.cpp" line="15"><![CDATA[check r->opcodes_0_str_value() == std::string("foobar") has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_cast_nested.cpp" line="16"><![CDATA[check r->opcodes_1_int()->value() == 66 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_cast_nested.cpp" line="17"><![CDATA[check r->opcodes_1_int_value() == 66 has passed]]></Info>
+      <TestingTime>1567</TestingTime>
+    </TestCase>
+    <TestCase name="test_cast_to_imported" file="/tests/spec/cpp_stl_11/test_cast_to_imported.cpp" line="10">
+      <Info file="/tests/spec/cpp_stl_11/test_cast_to_imported.cpp" line="15"><![CDATA[check r->one()->one() == 80 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_cast_to_imported.cpp" line="16"><![CDATA[check r->one_casted()->one() == 80 has passed]]></Info>
+      <TestingTime>109</TestingTime>
+    </TestCase>
+    <TestCase name="test_cast_to_top" file="/tests/spec/cpp_stl_11/test_cast_to_top.cpp" line="9">
+      <Info file="/tests/spec/cpp_stl_11/test_cast_to_top.cpp" line="14"><![CDATA[check r->code() == 80 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_cast_to_top.cpp" line="15"><![CDATA[check r->header()->code() == 65 has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_cast_to_top.cpp" line="16"><![CDATA[check r->header_casted()->code() == 65 has passed]]></Info>
+      <TestingTime>84</TestingTime>
+    </TestCase>
+    <TestCase name="test_combine_bool" file="/tests/spec/cpp_stl_11/test_combine_bool.cpp" line="9">
+      <Info file="/tests/spec/cpp_stl_11/test_combine_bool.cpp" line="14"><![CDATA[check r->bool_bit() == true has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_combine_bool.cpp" line="15"><![CDATA[check r->bool_calc_bit() == false has passed]]></Info>
+      <TestingTime>77</TestingTime>
+    </TestCase>
+    <TestCase name="test_combine_bytes" file="/tests/spec/cpp_stl_11/test_combine_bytes.cpp" line="9">
+      <Info file="/tests/spec/cpp_stl_11/test_combine_bytes.cpp" line="14"><![CDATA[check r->bytes_term() == std::string("\x66\x6F\x6F", 3) has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_combine_bytes.cpp" line="15"><![CDATA[check r->bytes_limit() == std::string("\x62\x61\x72\x7C", 4) has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_combine_bytes.cpp" line="16"><![CDATA[check r->bytes_eos() == std::string("\x62\x61\x7A\x40", 4) has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_combine_bytes.cpp" line="17"><![CDATA[check r->bytes_calc() == std::string("\x52\x6E\x44", 3) has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_combine_bytes.cpp" line="18"><![CDATA[check r->term_or_limit() == std::string("\x66\x6F\x6F", 3) has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_combine_bytes.cpp" line="19"><![CDATA[check r->term_or_eos() == std::string("\x62\x61\x7A\x40", 4) has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_combine_bytes.cpp" line="20"><![CDATA[check r->term_or_calc() == std::string("\x66\x6F\x6F", 3) has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_combine_bytes.cpp" line="21"><![CDATA[check r->limit_or_eos() == std::string("\x62\x61\x72\x7C", 4) has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_combine_bytes.cpp" line="22"><![CDATA[check r->limit_or_calc() == std::string("\x52\x6E\x44", 3) has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_combine_bytes.cpp" line="23"><![CDATA[check r->eos_or_calc() == std::string("\x62\x61\x7A\x40", 4) has passed]]></Info>
+      <TestingTime>95</TestingTime>
+    </TestCase>
+    <TestCase name="test_combine_enum" file="/tests/spec/cpp_stl_11/test_combine_enum.cpp" line="9">
+      <Info file="/tests/spec/cpp_stl_11/test_combine_enum.cpp" line="14"><![CDATA[check r->enum_u4() == combine_enum_t::ANIMAL_PIG has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_combine_enum.cpp" line="15"><![CDATA[check r->enum_u2() == combine_enum_t::ANIMAL_HORSE has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_combine_enum.cpp" line="16"><![CDATA[check r->enum_u4_u2() == combine_enum_t::ANIMAL_HORSE has passed]]></Info>
+      <TestingTime>110</TestingTime>
+    </TestCase>
+    <TestCase name="test_combine_str" file="/tests/spec/cpp_stl_11/test_combine_str.cpp" line="9">
+      <Info file="/tests/spec/cpp_stl_11/test_combine_str.cpp" line="14"><![CDATA[check r->str_term() == std::string("foo") has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_combine_str.cpp" line="15"><![CDATA[check r->str_limit() == std::string("bar|") has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_combine_str.cpp" line="16"><![CDATA[check r->str_eos() == std::string("baz@") has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_combine_str.cpp" line="17"><![CDATA[check r->str_calc() == std::string("bar") has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_combine_str.cpp" line="18"><![CDATA[check r->str_calc_bytes() == std::string("baz") has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_combine_str.cpp" line="19"><![CDATA[check r->term_or_limit() == std::string("foo") has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_combine_str.cpp" line="20"><![CDATA[check r->term_or_eos() == std::string("baz@") has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_combine_str.cpp" line="21"><![CDATA[check r->term_or_calc() == std::string("foo") has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_combine_str.cpp" line="22"><![CDATA[check r->term_or_calc_bytes() == std::string("baz") has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_combine_str.cpp" line="23"><![CDATA[check r->limit_or_eos() == std::string("bar|") has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_combine_str.cpp" line="24"><![CDATA[check r->limit_or_calc() == std::string("bar") has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_combine_str.cpp" line="25"><![CDATA[check r->limit_or_calc_bytes() == std::string("bar|") has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_combine_str.cpp" line="26"><![CDATA[check r->eos_or_calc() == std::string("bar") has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_combine_str.cpp" line="27"><![CDATA[check r->eos_or_calc_bytes() == std::string("baz@") has passed]]></Info>
+      <Info file="/tests/spec/cpp_stl_11/test_combine_str.cpp" line="28"><![CDATA[check r->calc_or_calc_bytes() == std::string("baz") has passed]]></Info>
+      <TestingTime>106</TestingTime>
+    </TestCase>
+    <TestCase name="test_debug_0" file="/tests/spec/cpp_stl_11/test_debug_0.cpp" line="9">
+      <Message file="boost.test framework" line="0"><![CDATA[Test case test_debug_0 did not check any assertions]]></Message>
+      <TestingTime>62</TestingTime>
+    </TestCase>
+    <TestCase name="test_debug_array_user" file="/tests/spec/cpp_stl_11/test_debug_array_user.cpp" line="7">
+      <Exception file="unknown location" line="0"><![CDATA[memory access violation at address: 0x00000008: no mapping at fault address]]>
+        <LastCheckpoint file="/tests/spec/cpp_stl_11/test_debug_array_user.cpp" line="7"><![CDATA["test_debug_array_user" test entry]]></LastCheckpoint>
+      </Exception>
+      <Message file="./boost/test/impl/unit_test_log.ipp" line="261"><![CDATA[Test is aborted]]></Message>
+      <TestingTime>122</TestingTime>
+    </TestCase>
+    <Message file="./boost/test/impl/unit_test_log.ipp" line="261"><![CDATA[Test is aborted]]></Message>
+  </TestSuite>
+</TestLog>

--- a/builder/spec/cpp/boost_aborted_msvc/test_out/cpp_stl_11/results.xml
+++ b/builder/spec/cpp/boost_aborted_msvc/test_out/cpp_stl_11/results.xml
@@ -1,0 +1,226 @@
+<TestLog>
+  <TestSuite name="C++/STL test units for Kaitai Struct">
+    <TestCase name="test_bcd_user_type_be" file="C:\projects\ci-targets\tests\spec\cpp_stl_11\test_bcd_user_type_be.cpp" line="9">
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bcd_user_type_be.cpp" line="14"><![CDATA[check r->ltr()->as_int() == 12345678 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bcd_user_type_be.cpp" line="15"><![CDATA[check r->ltr()->as_str() == std::string("12345678") has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bcd_user_type_be.cpp" line="16"><![CDATA[check r->rtl()->as_int() == 87654321 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bcd_user_type_be.cpp" line="17"><![CDATA[check r->rtl()->as_str() == std::string("87654321") has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bcd_user_type_be.cpp" line="18"><![CDATA[check r->leading_zero_ltr()->as_int() == 123456 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bcd_user_type_be.cpp" line="19"><![CDATA[check r->leading_zero_ltr()->as_str() == std::string("00123456") has passed]]></Info>
+      <TestingTime>1474</TestingTime>
+    </TestCase>
+    <TestCase name="test_bcd_user_type_le" file="C:\projects\ci-targets\tests\spec\cpp_stl_11\test_bcd_user_type_le.cpp" line="9">
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bcd_user_type_le.cpp" line="14"><![CDATA[check r->ltr()->as_int() == 12345678 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bcd_user_type_le.cpp" line="15"><![CDATA[check r->ltr()->as_str() == std::string("12345678") has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bcd_user_type_le.cpp" line="16"><![CDATA[check r->rtl()->as_int() == 87654321 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bcd_user_type_le.cpp" line="17"><![CDATA[check r->rtl()->as_str() == std::string("87654321") has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bcd_user_type_le.cpp" line="18"><![CDATA[check r->leading_zero_ltr()->as_int() == 123456 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bcd_user_type_le.cpp" line="19"><![CDATA[check r->leading_zero_ltr()->as_str() == std::string("00123456") has passed]]></Info>
+      <TestingTime>808</TestingTime>
+    </TestCase>
+    <TestCase name="test_bits_byte_aligned" file="C:\projects\ci-targets\tests\spec\cpp_stl_11\test_bits_byte_aligned.cpp" line="9">
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_byte_aligned.cpp" line="14"><![CDATA[check r->one() == 20 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_byte_aligned.cpp" line="15"><![CDATA[check r->byte_1() == 65 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_byte_aligned.cpp" line="16"><![CDATA[check r->two() == 2 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_byte_aligned.cpp" line="17"><![CDATA[check r->three() == false has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_byte_aligned.cpp" line="18"><![CDATA[check r->byte_2() == 75 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_byte_aligned.cpp" line="19"><![CDATA[check r->four() == 2892 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_byte_aligned.cpp" line="20"><![CDATA[check r->byte_3() == std::string("\xFF", 1) has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_byte_aligned.cpp" line="21"><![CDATA[check r->full_byte() == 255 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_byte_aligned.cpp" line="22"><![CDATA[check r->byte_4() == 80 has passed]]></Info>
+      <TestingTime>828</TestingTime>
+    </TestCase>
+    <TestCase name="test_bits_enum" file="C:\projects\ci-targets\tests\spec\cpp_stl_11\test_bits_enum.cpp" line="9">
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_enum.cpp" line="14"><![CDATA[check r->one() == bits_enum_t::ANIMAL_PLATYPUS has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_enum.cpp" line="15"><![CDATA[check r->two() == bits_enum_t::ANIMAL_HORSE has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_enum.cpp" line="16"><![CDATA[check r->three() == bits_enum_t::ANIMAL_CAT has passed]]></Info>
+      <TestingTime>503</TestingTime>
+    </TestCase>
+    <TestCase name="test_bits_seq_endian_combo" file="C:\projects\ci-targets\tests\spec\cpp_stl_11\test_bits_seq_endian_combo.cpp" line="9">
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_seq_endian_combo.cpp" line="14"><![CDATA[check r->be1() == 59 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_seq_endian_combo.cpp" line="15"><![CDATA[check r->be2() == 187 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_seq_endian_combo.cpp" line="16"><![CDATA[check r->le3() == 163 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_seq_endian_combo.cpp" line="17"><![CDATA[check r->be4() == 20 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_seq_endian_combo.cpp" line="18"><![CDATA[check r->le5() == 10 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_seq_endian_combo.cpp" line="19"><![CDATA[check r->le6() == 36 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_seq_endian_combo.cpp" line="20"><![CDATA[check r->le7() == 26 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_seq_endian_combo.cpp" line="21"><![CDATA[check r->be8() == true has passed]]></Info>
+      <TestingTime>731</TestingTime>
+    </TestCase>
+    <TestCase name="test_bits_shift_by_b32_le" file="C:\projects\ci-targets\tests\spec\cpp_stl_11\test_bits_shift_by_b32_le.cpp" line="9">
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_shift_by_b32_le.cpp" line="14"><![CDATA[check r->a() == 4294967295UL has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_shift_by_b32_le.cpp" line="15"><![CDATA[check r->b() == 0 has passed]]></Info>
+      <TestingTime>340</TestingTime>
+    </TestCase>
+    <TestCase name="test_bits_shift_by_b64_le" file="C:\projects\ci-targets\tests\spec\cpp_stl_11\test_bits_shift_by_b64_le.cpp" line="9">
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_shift_by_b64_le.cpp" line="14"><![CDATA[check r->a() == 18446744073709551615ULL has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_shift_by_b64_le.cpp" line="15"><![CDATA[check r->b() == 0 has passed]]></Info>
+      <TestingTime>330</TestingTime>
+    </TestCase>
+    <TestCase name="test_bits_signed_res_b32_be" file="C:\projects\ci-targets\tests\spec\cpp_stl_11\test_bits_signed_res_b32_be.cpp" line="9">
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_signed_res_b32_be.cpp" line="14"><![CDATA[check r->a() == 4294967295UL has passed]]></Info>
+      <TestingTime>266</TestingTime>
+    </TestCase>
+    <TestCase name="test_bits_signed_res_b32_le" file="C:\projects\ci-targets\tests\spec\cpp_stl_11\test_bits_signed_res_b32_le.cpp" line="9">
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_signed_res_b32_le.cpp" line="14"><![CDATA[check r->a() == 4294967295UL has passed]]></Info>
+      <TestingTime>223</TestingTime>
+    </TestCase>
+    <TestCase name="test_bits_signed_shift_b32_le" file="C:\projects\ci-targets\tests\spec\cpp_stl_11\test_bits_signed_shift_b32_le.cpp" line="9">
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_signed_shift_b32_le.cpp" line="14"><![CDATA[check r->a() == 0 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_signed_shift_b32_le.cpp" line="15"><![CDATA[check r->b() == 255 has passed]]></Info>
+      <TestingTime>357</TestingTime>
+    </TestCase>
+    <TestCase name="test_bits_signed_shift_b64_le" file="C:\projects\ci-targets\tests\spec\cpp_stl_11\test_bits_signed_shift_b64_le.cpp" line="9">
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_signed_shift_b64_le.cpp" line="14"><![CDATA[check r->a() == 0 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_signed_shift_b64_le.cpp" line="15"><![CDATA[check r->b() == 255 has passed]]></Info>
+      <TestingTime>328</TestingTime>
+    </TestCase>
+    <TestCase name="test_bits_simple" file="C:\projects\ci-targets\tests\spec\cpp_stl_11\test_bits_simple.cpp" line="9">
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_simple.cpp" line="14"><![CDATA[check r->byte_1() == 80 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_simple.cpp" line="15"><![CDATA[check r->byte_2() == 65 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_simple.cpp" line="16"><![CDATA[check r->bits_a() == false has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_simple.cpp" line="17"><![CDATA[check r->bits_b() == 4 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_simple.cpp" line="18"><![CDATA[check r->bits_c() == 3 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_simple.cpp" line="19"><![CDATA[check r->large_bits_1() == 300 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_simple.cpp" line="20"><![CDATA[check r->spacer() == 5 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_simple.cpp" line="21"><![CDATA[check r->large_bits_2() == 1329 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_simple.cpp" line="22"><![CDATA[check r->normal_s2() == -1 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_simple.cpp" line="23"><![CDATA[check r->byte_8_9_10() == 5259587 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_simple.cpp" line="24"><![CDATA[check r->byte_11_to_14() == 1261262125 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_simple.cpp" line="25"><![CDATA[check r->byte_15_to_19() == 293220057087LL has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_simple.cpp" line="26"><![CDATA[check r->byte_20_to_27() == 18446744073709551615ULL has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_simple.cpp" line="27"><![CDATA[check r->test_if_b1() == 123 has passed]]></Info>
+      <TestingTime>2104</TestingTime>
+    </TestCase>
+    <TestCase name="test_bits_simple_le" file="C:\projects\ci-targets\tests\spec\cpp_stl_11\test_bits_simple_le.cpp" line="9">
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_simple_le.cpp" line="14"><![CDATA[check r->byte_1() == 80 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_simple_le.cpp" line="15"><![CDATA[check r->byte_2() == 65 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_simple_le.cpp" line="16"><![CDATA[check r->bits_a() == true has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_simple_le.cpp" line="17"><![CDATA[check r->bits_b() == 1 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_simple_le.cpp" line="18"><![CDATA[check r->bits_c() == 4 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_simple_le.cpp" line="19"><![CDATA[check r->large_bits_1() == 331 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_simple_le.cpp" line="20"><![CDATA[check r->spacer() == 3 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_simple_le.cpp" line="21"><![CDATA[check r->large_bits_2() == 393 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_simple_le.cpp" line="22"><![CDATA[check r->normal_s2() == -1 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_simple_le.cpp" line="23"><![CDATA[check r->byte_8_9_10() == 4407632 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_simple_le.cpp" line="24"><![CDATA[check r->byte_11_to_14() == 760556875 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_simple_le.cpp" line="25"><![CDATA[check r->byte_15_to_19() == 1099499455812LL has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_simple_le.cpp" line="26"><![CDATA[check r->byte_20_to_27() == 18446744073709551615ULL has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_simple_le.cpp" line="27"><![CDATA[check r->test_if_b1() == 123 has passed]]></Info>
+      <TestingTime>1501</TestingTime>
+    </TestCase>
+    <TestCase name="test_bits_unaligned_b32_be" file="C:\projects\ci-targets\tests\spec\cpp_stl_11\test_bits_unaligned_b32_be.cpp" line="9">
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_unaligned_b32_be.cpp" line="14"><![CDATA[check r->a() == true has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_unaligned_b32_be.cpp" line="15"><![CDATA[check r->b() == 3648472617UL has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_unaligned_b32_be.cpp" line="16"><![CDATA[check r->c() == 10 has passed]]></Info>
+      <TestingTime>597</TestingTime>
+    </TestCase>
+    <TestCase name="test_bits_unaligned_b32_le" file="C:\projects\ci-targets\tests\spec\cpp_stl_11\test_bits_unaligned_b32_le.cpp" line="9">
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_unaligned_b32_le.cpp" line="14"><![CDATA[check r->a() == false has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_unaligned_b32_le.cpp" line="15"><![CDATA[check r->b() == 173137398 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_unaligned_b32_le.cpp" line="16"><![CDATA[check r->c() == 69 has passed]]></Info>
+      <TestingTime>386</TestingTime>
+    </TestCase>
+    <TestCase name="test_bits_unaligned_b64_be" file="C:\projects\ci-targets\tests\spec\cpp_stl_11\test_bits_unaligned_b64_be.cpp" line="9">
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_unaligned_b64_be.cpp" line="14"><![CDATA[check r->a() == true has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_unaligned_b64_be.cpp" line="15"><![CDATA[check r->b() == 15670070570729969769ULL has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_unaligned_b64_be.cpp" line="16"><![CDATA[check r->c() == 14 has passed]]></Info>
+      <TestingTime>537</TestingTime>
+    </TestCase>
+    <TestCase name="test_bits_unaligned_b64_le" file="C:\projects\ci-targets\tests\spec\cpp_stl_11\test_bits_unaligned_b64_le.cpp" line="9">
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_unaligned_b64_le.cpp" line="14"><![CDATA[check r->a() == false has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_unaligned_b64_le.cpp" line="15"><![CDATA[check r->b() == 1902324737369038326LL has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bits_unaligned_b64_le.cpp" line="16"><![CDATA[check r->c() == 71 has passed]]></Info>
+      <TestingTime>819</TestingTime>
+    </TestCase>
+    <TestCase name="test_buffered_struct" file="C:\projects\ci-targets\tests\spec\cpp_stl_11\test_buffered_struct.cpp" line="9">
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_buffered_struct.cpp" line="14"><![CDATA[check r->len1() == 16 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_buffered_struct.cpp" line="15"><![CDATA[check r->block1()->number1() == 66 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_buffered_struct.cpp" line="16"><![CDATA[check r->block1()->number2() == 67 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_buffered_struct.cpp" line="17"><![CDATA[check r->len2() == 8 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_buffered_struct.cpp" line="18"><![CDATA[check r->block2()->number1() == 68 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_buffered_struct.cpp" line="19"><![CDATA[check r->block2()->number2() == 69 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_buffered_struct.cpp" line="20"><![CDATA[check r->finisher() == 238 has passed]]></Info>
+      <TestingTime>1136</TestingTime>
+    </TestCase>
+    <TestCase name="test_bytes_pad_term" file="C:\projects\ci-targets\tests\spec\cpp_stl_11\test_bytes_pad_term.cpp" line="9">
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bytes_pad_term.cpp" line="14"><![CDATA[check r->str_pad() == std::string("\x73\x74\x72\x31", 4) has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bytes_pad_term.cpp" line="15"><![CDATA[check r->str_term() == std::string("\x73\x74\x72\x32\x66\x6F\x6F", 7) has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bytes_pad_term.cpp" line="16"><![CDATA[check r->str_term_and_pad() == std::string("\x73\x74\x72\x2B\x2B\x2B\x33\x62\x61\x72\x2B\x2B\x2B", 13) has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_bytes_pad_term.cpp" line="17"><![CDATA[check r->str_term_include() == std::string("\x73\x74\x72\x34\x62\x61\x7A\x40", 8) has passed]]></Info>
+      <TestingTime>1071</TestingTime>
+    </TestCase>
+    <TestCase name="test_cast_nested" file="C:\projects\ci-targets\tests\spec\cpp_stl_11\test_cast_nested.cpp" line="9">
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_cast_nested.cpp" line="14"><![CDATA[check r->opcodes_0_str()->value() == std::string("foobar") has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_cast_nested.cpp" line="15"><![CDATA[check r->opcodes_0_str_value() == std::string("foobar") has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_cast_nested.cpp" line="16"><![CDATA[check r->opcodes_1_int()->value() == 66 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_cast_nested.cpp" line="17"><![CDATA[check r->opcodes_1_int_value() == 66 has passed]]></Info>
+      <TestingTime>1068</TestingTime>
+    </TestCase>
+    <TestCase name="test_cast_to_imported" file="C:\projects\ci-targets\tests\spec\cpp_stl_11\test_cast_to_imported.cpp" line="10">
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_cast_to_imported.cpp" line="15"><![CDATA[check r->one()->one() == 80 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_cast_to_imported.cpp" line="16"><![CDATA[check r->one_casted()->one() == 80 has passed]]></Info>
+      <TestingTime>330</TestingTime>
+    </TestCase>
+    <TestCase name="test_cast_to_top" file="C:\projects\ci-targets\tests\spec\cpp_stl_11\test_cast_to_top.cpp" line="9">
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_cast_to_top.cpp" line="14"><![CDATA[check r->code() == 80 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_cast_to_top.cpp" line="15"><![CDATA[check r->header()->code() == 65 has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_cast_to_top.cpp" line="16"><![CDATA[check r->header_casted()->code() == 65 has passed]]></Info>
+      <TestingTime>401</TestingTime>
+    </TestCase>
+    <TestCase name="test_combine_bool" file="C:\projects\ci-targets\tests\spec\cpp_stl_11\test_combine_bool.cpp" line="9">
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_combine_bool.cpp" line="14"><![CDATA[check r->bool_bit() == true has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_combine_bool.cpp" line="15"><![CDATA[check r->bool_calc_bit() == false has passed]]></Info>
+      <TestingTime>301</TestingTime>
+    </TestCase>
+    <TestCase name="test_combine_bytes" file="C:\projects\ci-targets\tests\spec\cpp_stl_11\test_combine_bytes.cpp" line="9">
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_combine_bytes.cpp" line="14"><![CDATA[check r->bytes_term() == std::string("\x66\x6F\x6F", 3) has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_combine_bytes.cpp" line="15"><![CDATA[check r->bytes_limit() == std::string("\x62\x61\x72\x7C", 4) has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_combine_bytes.cpp" line="16"><![CDATA[check r->bytes_eos() == std::string("\x62\x61\x7A\x40", 4) has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_combine_bytes.cpp" line="17"><![CDATA[check r->bytes_calc() == std::string("\x52\x6E\x44", 3) has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_combine_bytes.cpp" line="18"><![CDATA[check r->term_or_limit() == std::string("\x66\x6F\x6F", 3) has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_combine_bytes.cpp" line="19"><![CDATA[check r->term_or_eos() == std::string("\x62\x61\x7A\x40", 4) has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_combine_bytes.cpp" line="20"><![CDATA[check r->term_or_calc() == std::string("\x66\x6F\x6F", 3) has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_combine_bytes.cpp" line="21"><![CDATA[check r->limit_or_eos() == std::string("\x62\x61\x72\x7C", 4) has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_combine_bytes.cpp" line="22"><![CDATA[check r->limit_or_calc() == std::string("\x52\x6E\x44", 3) has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_combine_bytes.cpp" line="23"><![CDATA[check r->eos_or_calc() == std::string("\x62\x61\x7A\x40", 4) has passed]]></Info>
+      <TestingTime>1068</TestingTime>
+    </TestCase>
+    <TestCase name="test_combine_enum" file="C:\projects\ci-targets\tests\spec\cpp_stl_11\test_combine_enum.cpp" line="9">
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_combine_enum.cpp" line="14"><![CDATA[check r->enum_u4() == combine_enum_t::ANIMAL_PIG has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_combine_enum.cpp" line="15"><![CDATA[check r->enum_u2() == combine_enum_t::ANIMAL_HORSE has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_combine_enum.cpp" line="16"><![CDATA[check r->enum_u4_u2() == combine_enum_t::ANIMAL_HORSE has passed]]></Info>
+      <TestingTime>375</TestingTime>
+    </TestCase>
+    <TestCase name="test_combine_str" file="C:\projects\ci-targets\tests\spec\cpp_stl_11\test_combine_str.cpp" line="9">
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_combine_str.cpp" line="14"><![CDATA[check r->str_term() == std::string("foo") has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_combine_str.cpp" line="15"><![CDATA[check r->str_limit() == std::string("bar|") has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_combine_str.cpp" line="16"><![CDATA[check r->str_eos() == std::string("baz@") has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_combine_str.cpp" line="17"><![CDATA[check r->str_calc() == std::string("bar") has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_combine_str.cpp" line="18"><![CDATA[check r->str_calc_bytes() == std::string("baz") has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_combine_str.cpp" line="19"><![CDATA[check r->term_or_limit() == std::string("foo") has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_combine_str.cpp" line="20"><![CDATA[check r->term_or_eos() == std::string("baz@") has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_combine_str.cpp" line="21"><![CDATA[check r->term_or_calc() == std::string("foo") has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_combine_str.cpp" line="22"><![CDATA[check r->term_or_calc_bytes() == std::string("baz") has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_combine_str.cpp" line="23"><![CDATA[check r->limit_or_eos() == std::string("bar|") has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_combine_str.cpp" line="24"><![CDATA[check r->limit_or_calc() == std::string("bar") has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_combine_str.cpp" line="25"><![CDATA[check r->limit_or_calc_bytes() == std::string("bar|") has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_combine_str.cpp" line="26"><![CDATA[check r->eos_or_calc() == std::string("bar") has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_combine_str.cpp" line="27"><![CDATA[check r->eos_or_calc_bytes() == std::string("baz@") has passed]]></Info>
+      <Info file="C:/projects/ci-targets/tests/spec/cpp_stl_11/test_combine_str.cpp" line="28"><![CDATA[check r->calc_or_calc_bytes() == std::string("baz") has passed]]></Info>
+      <TestingTime>1619</TestingTime>
+    </TestCase>
+    <TestCase name="test_debug_0" file="C:\projects\ci-targets\tests\spec\cpp_stl_11\test_debug_0.cpp" line="9">
+      <Message file="boost.test framework" line="244"><![CDATA[Test case test_debug_0 did not check any assertions]]></Message>
+      <TestingTime>65</TestingTime>
+    </TestCase>
+    <TestCase name="test_debug_array_user" file="C:\projects\ci-targets\tests\spec\cpp_stl_11\test_debug_array_user.cpp" line="7">
+      <Exception file="unknown location" line="0"><![CDATA[memory access violation occurred at address 0x00000008, while attempting to  read inaccessible data]]>
+        <LastCheckpoint file="C:\projects\ci-targets\tests\spec\cpp_stl_11\test_debug_array_user.cpp" line="7"><![CDATA["test_debug_array_user" test entry]]></LastCheckpoint>
+      </Exception>
+      <Message file="C:/Tools/vcpkg/buildtrees/boost-test/src/ost-1.71.0-4b298197d6/include/boost/test/impl/unit_test_log.ipp" line="205"><![CDATA[Test is aborted]]></Message>
+      <TestingTime>504</TestingTime>
+    </TestCase>
+    <Message file="C:/Tools/vcpkg/buildtrees/boost-test/src/ost-1.71.0-4b298197d6/include/boost/test/impl/unit_test_log.ipp" line="205"><![CDATA[Test is aborted]]></Message>
+  </TestSuite>
+</TestLog>

--- a/builder/spec/cpp/cpp_builder_spec.rb
+++ b/builder/spec/cpp/cpp_builder_spec.rb
@@ -1,4 +1,5 @@
 require_relative '../../cpp_builder'
+require_relative '../../../aggregate/boost_test_parser'
 require 'rspec' # normally not needed, but RubyMine doesn't autocomplete RSpec methods without it
 
 RSpec.describe CppBuilder do
@@ -429,6 +430,40 @@ RSpec.describe CppBuilder do
       it 'parses failed build information' do
         expect(@builder.parse_failed_build('test_out/cpp_stl_98/build-2.log')).to eq [
           'c:/projects/ci-targets/tests/spec/cpp_stl_98/test_expr_calc_array_ops.cpp',
+        ]
+      end
+    end
+  end
+
+  # The log comes from https://github.com/kaitai-io/ci_artifacts/blob/8b27b4eeaa8653cd33940fb620c184cd9763e6f0/test_out/cpp_stl_11/results.xml
+  context 'boost_aborted_gcc' do
+    before :context do
+      Dir.chdir("#{@spec_dir}/boost_aborted_gcc")
+    end
+
+    describe 'BoostTestParser#aborted_tests' do
+      it 'parses aborted tests' do
+        infile = 'test_out/cpp_stl_11'
+        p = BoostTestParser.new("#{infile}/results.xml")
+        expect(p.aborted_tests).to eq [
+          'test_debug_array_user',
+        ]
+      end
+    end
+  end
+
+  # The log comes from https://github.com/kaitai-io/ci_artifacts/blob/a588faa1a35b658116d4ab5551f0863e61a7324c/test_out/cpp_stl_11/results.xml
+  context 'boost_aborted_msvc' do
+    before :context do
+      Dir.chdir("#{@spec_dir}/boost_aborted_msvc")
+    end
+
+    describe 'BoostTestParser#aborted_tests' do
+      it 'parses aborted tests' do
+        infile = 'test_out/cpp_stl_11'
+        p = BoostTestParser.new("#{infile}/results.xml")
+        expect(p.aborted_tests).to eq [
+          'test_debug_array_user',
         ]
       end
     end

--- a/ci-cpp_stl
+++ b/ci-cpp_stl
@@ -17,11 +17,6 @@ CPP_TEST_OUT_DIR="$3"
 echo 'Running Valgrind checks...'
 if valgrind --version; then
 	./valgrind-cpp_stl "$SRC_DIR" "$CPP_TEST_OUT_DIR" || :
-
-	# For some obscure reason, valgrind generates this file as 0600 (owner-readable only).
-	# This disrupts invocation from Docker pipeline, as after return back from the Docker container
-	# this will become root-owned and root-only-readable file. We fix it here.
-	chmod 644 "$CPP_TEST_OUT_DIR/valgrind.xml"
 else
 	echo 'Valgrind not found :-('
 

--- a/valgrind-cpp_stl
+++ b/valgrind-cpp_stl
@@ -12,4 +12,36 @@ CPP_TEST_OUT_DIR="$2"
 
 OBJ_DIR="$SRC_DIR/bin"
 
-valgrind --leak-check=full --xml=yes --xml-file="$CPP_TEST_OUT_DIR/valgrind.xml" "$OBJ_DIR/ks_tests"
+run_valgrind() {
+	_attempt_no=$1
+	shift
+	_xml_file="$CPP_TEST_OUT_DIR/valgrind-${_attempt_no}.xml"
+	valgrind --leak-check=full --xml=yes --xml-file="${_xml_file}" "$OBJ_DIR/ks_tests" "$@"
+
+	# For some obscure reason, valgrind generates this file as 0600 (owner-readable only).
+	# This disrupts invocation from Docker pipeline, as after return back from the Docker container
+	# this will become root-owned and root-only-readable file. We fix it here.
+	chmod 644 "${_xml_file}"
+}
+
+read_next=1
+
+run_attempt=0
+set --
+
+while [ -n "${read_next}" ]; do
+	run_attempt=$((run_attempt+1))
+	run_valgrind "${run_attempt}" "$@" || :
+
+	# if the `aborted_tests-{N}.txt` file is empty, then there were no aborted
+	# tests and it's the last attempt we need to process
+	read_next=
+	while IFS= read -r line; do
+		read_next=1
+		set -- "$@" "--run_test=!${line}"
+	done < "${CPP_TEST_OUT_DIR}/aborted_tests-${run_attempt}.txt"
+done
+
+# Currently, aggregate/convert_to_json only processes "valgrind.xml", so we
+# make a copy with that name of the last (successful) attempt's log
+cp -v "$CPP_TEST_OUT_DIR/valgrind-${run_attempt}.xml" "$CPP_TEST_OUT_DIR/valgrind.xml"


### PR DESCRIPTION
Currently, when a single C++ test aborts at runtime (typically due to a `memory access violation`), the entire test suite is terminated. See [Class `test_observer` > `test_aborted()`](https://www.boost.org/doc/libs/1_84_0/libs/test/doc/html/boost/unit_test/test_observer.html#idm46380-bb):

> Called when a critical error is detected.
>
> The critical errors are mainly the signals sent by the system and caught by the Boost.Test framework. Since the running binary may be in incoherent/instable state, the test execution is aborted and all remaining tests are discarded.



This PR allows the CI to recover from that by detecting the aborted test and running the test executable again excluding the previously aborted tests (using the `--run_test=!<absolute_spec>` option, see [Test unit filtering > Relative specification](https://www.boost.org/doc/libs/1_84_0/libs/test/doc/html/boost_test/runtime_config/test_unit_filtering.html#boost_test.runtime_config.test_unit_filtering.relative_specification)).