### PR TITLE
Adjust one more test that was forgotten to update after rebase of #92

### DIFF
--- a/formats_err/type_unknown_many.ksy
+++ b/formats_err/type_unknown_many.ksy
@@ -1,10 +1,10 @@
-# type_unknown_many.ksy: /seq/0:
+# type_unknown_many.ksy: /seq/0/type:
 # 	error: unable to find type 'some_unknown_name', searching from type_unknown_many
 #
-# type_unknown_many.ksy: /seq/1:
+# type_unknown_many.ksy: /seq/1/type:
 # 	error: unable to find type 'also_unknown_name', searching from type_unknown_many
 #
-# type_unknown_many.ksy: /seq/2:
+# type_unknown_many.ksy: /seq/2/enum:
 # 	error: unable to find enum 'unknown_enum', searching from type_unknown_many
 #
 meta:


### PR DESCRIPTION
Fixes the test
```
[info] - type_unknown_many *** FAILED ***
[info]   type_unknown_many.ksy: /seq/0/type:
[info]   	error: unable to find type 'some_unknown_name', searching from type_unknown_many
[info]
[info]   type_unknown_many.ksy: /seq/1/type:
[info]   	error: unable to find type 'also_unknown_name', searching from type_unknown_many
[info]
[info]   type_unknown_many.ksy: /seq/2/enum:
[info]   	error: unable to find enum 'unknown_enum', searching from type_unknown_many
[info]    did not equal type_unknown_many.ksy: /seq/0:
[info]   	error: unable to find type 'some_unknown_name', searching from type_unknown_many
[info]
[info]   type_unknown_many.ksy: /seq/1:
[info]   	error: unable to find type 'also_unknown_name', searching from type_unknown_many
[info]
[info]   type_unknown_many.ksy: /seq/2:
[info]   	error: unable to find enum 'unknown_enum', searching from type_unknown_many (SimpleMatchers.scala:34)
```