### PR TITLE
Use filename instead of name

### DIFF
--- a/formats_err/meta_imports_rel2.ksy
+++ b/formats_err/meta_imports_rel2.ksy
@@ -1,5 +1,5 @@
 # meta_imports_rel_unknown: /meta/imports/0:
-# 	error: ../tests/formats_err/unknown_relative_name.ksy (No such file or directory)
+# 	error: unknown_relative_name.ksy (No such file or directory)
 #
 meta:
   id: meta_imports_rel2

--- a/formats_err/meta_imports_rel2.ksy
+++ b/formats_err/meta_imports_rel2.ksy
@@ -1,4 +1,4 @@
-# meta_imports_rel_unknown: /meta/imports/0:
+# meta_imports_rel_unknown.ksy: /meta/imports/0:
 # 	error: unknown_relative_name.ksy (No such file or directory)
 #
 meta:

--- a/formats_err/meta_imports_rel_unknown.ksy
+++ b/formats_err/meta_imports_rel_unknown.ksy
@@ -1,5 +1,5 @@
 # meta_imports_rel_unknown: /meta/imports/0:
-# 	error: ../tests/formats_err/unknown_relative_name.ksy (No such file or directory)
+# 	error: unknown_relative_name.ksy (No such file or directory)
 #
 meta:
   id: meta_imports_rel_unknown

--- a/formats_err/meta_imports_rel_unknown.ksy
+++ b/formats_err/meta_imports_rel_unknown.ksy
@@ -1,4 +1,4 @@
-# meta_imports_rel_unknown: /meta/imports/0:
+# meta_imports_rel_unknown.ksy: /meta/imports/0:
 # 	error: unknown_relative_name.ksy (No such file or directory)
 #
 meta:


### PR DESCRIPTION
This PR
- fixes paths in errors that was changed in https://github.com/kaitai-io/kaitai_struct_compiler/commit/2851d203be30d2e66e5d4f3b9499355c94cc415a
- add a `.ksy` suffix to the file names which is implemented in https://github.com/kaitai-io/kaitai_struct_compiler/pull/285