### PR TITLE
Revert "Translator: allow go, but not by default" - Go translator is no worse than others

### DIFF
--- a/translator/src/main/scala/io/kaitai/struct/testtranslator/Main.scala
+++ b/translator/src/main/scala/io/kaitai/struct/testtranslator/Main.scala
@@ -30,8 +30,6 @@ object Main extends App {
     "rust"
   )
 
-  val ALL_GOOD_LANGS = ALL_LANGS.filterNot(_ == "go")
-
   val INIT_OBJ_TYPE = "unique_top_level_container"
   val INIT_OBJ_NAME = "q1w2e3"
 
@@ -61,7 +59,7 @@ object Main extends App {
 
     opt[String]('t', "target").unbounded().valueName("<language>").action { (x, c) =>
       if (x == "all") {
-        c.copy(targets = ALL_GOOD_LANGS)
+        c.copy(targets = ALL_LANGS)
       } else {
         c.copy(targets = c.targets :+ x)
       }
@@ -95,7 +93,7 @@ object Main extends App {
     case None => System.exit(1)
     case Some(config0) =>
       val config = if (config0.targets.isEmpty) {
-        config0.copy(targets = ALL_GOOD_LANGS)
+        config0.copy(targets = ALL_LANGS)
       } else {
         config0
       }


### PR DESCRIPTION
The Go translator is not included into `all` category since https://github.com/kaitai-io/kaitai_struct_tests/commit/0590480901f6074350800bd3b87b7420182b6cd7, which is strange. It's implementation not worse that, for example, Construct translator and it actually have more high rating on https://ci.kaitai.io.