### PR TITLE
Lua, Python: use special translation method for expected value of float checks as well

### DIFF
--- a/translator/src/main/scala/io/kaitai/struct/testtranslator/specgenerators/LuaSG.scala
+++ b/translator/src/main/scala/io/kaitai/struct/testtranslator/specgenerators/LuaSG.scala
@@ -56,7 +56,7 @@ class LuaSG(spec: TestSpec, provider: ClassTypeProvider) extends BaseGenerator(s
 
   override def floatEquality(check: TestEquals): Unit = {
     val actStr = translateAct(check.actual)
-    val expStr = translator.translate(check.expected)
+    val expStr = translateExp(check.expected)
     out.puts(s"luaunit.assertAlmostEquals($actStr, $expStr, 0.000001)")
   }
 

--- a/translator/src/main/scala/io/kaitai/struct/testtranslator/specgenerators/PythonSG.scala
+++ b/translator/src/main/scala/io/kaitai/struct/testtranslator/specgenerators/PythonSG.scala
@@ -53,7 +53,7 @@ class PythonSG(spec: TestSpec, provider: ClassTypeProvider) extends BaseGenerato
 
   override def floatEquality(check: TestEquals): Unit = {
     val actStr = translateAct(check.actual)
-    val expStr = translator.translate(check.expected)
+    val expStr = translateExp(check.expected)
     out.puts(s"self.assertAlmostEqual($actStr, $expStr, 6)")
   }
 


### PR DESCRIPTION
If it is used in `simpleEquality`, then it should be used in `floatEquality` as well