### PR TITLE
Nim: slightly tweak KST generator to generate more automatic tests

### DIFF
--- a/spec/nim/texpr_sizeof_type_0.nim
+++ b/spec/nim/texpr_sizeof_type_0.nim
@@ -6,4 +6,4 @@ import auxiliary/test_utils
 
 let r = ExprSizeofType0.fromFile("../../src/fixed_struct.bin")
 
-assert r.sizeofBlock == ((1 + 4) + 2)
+assert r.sizeofBlock == (1 + 4) + 2

--- a/spec/nim/texpr_sizeof_type_1.nim
+++ b/spec/nim/texpr_sizeof_type_1.nim
@@ -6,5 +6,5 @@ import auxiliary/test_utils
 
 let r = ExprSizeofType1.fromFile("../../src/fixed_struct.bin")
 
-assert r.sizeofBlock == (((1 + 4) + 2) + 4)
+assert r.sizeofBlock == ((1 + 4) + 2) + 4
 assert r.sizeofSubblock == 4

--- a/spec/nim/texpr_sizeof_value_0.nim
+++ b/spec/nim/texpr_sizeof_value_0.nim
@@ -6,8 +6,8 @@ import auxiliary/test_utils
 
 let r = ExprSizeofValue0.fromFile("../../src/fixed_struct.bin")
 
-assert r.selfSizeof == (((1 + 4) + 2) + 2)
-assert r.sizeofBlock == ((1 + 4) + 2)
+assert r.selfSizeof == ((1 + 4) + 2) + 2
+assert r.sizeofBlock == (1 + 4) + 2
 assert r.sizeofBlockA == 1
 assert r.sizeofBlockB == 4
 assert r.sizeofBlockC == 2

--- a/spec/nim/texpr_sizeof_value_sized.nim
+++ b/spec/nim/texpr_sizeof_value_sized.nim
@@ -6,7 +6,7 @@ import auxiliary/test_utils
 
 let r = ExprSizeofValueSized.fromFile("../../src/fixed_struct.bin")
 
-assert r.selfSizeof == (12 + 2)
+assert r.selfSizeof == 12 + 2
 assert r.sizeofBlock == 12
 assert r.sizeofBlockA == 1
 assert r.sizeofBlockB == 4

--- a/spec/nim/tposition_in_seq.nim
+++ b/spec/nim/tposition_in_seq.nim
@@ -6,4 +6,4 @@ import auxiliary/test_utils
 
 let r = PositionInSeq.fromFile("../../src/position_in_seq.bin")
 
-assert r.numbers == @[uint8((0 + 1)), 2, 3]
+assert r.numbers == @[uint8(0 + 1), 2, 3]

--- a/spec/nim/trepeat_until_complex.nim
+++ b/spec/nim/trepeat_until_complex.nim
@@ -8,16 +8,16 @@ let r = RepeatUntilComplex.fromFile("../../src/repeat_until_complex.bin")
 
 assert len(r.first) == 3
 assert r.first[0].count == 4
-assert r.first[0].values == @[uint8((0 + 1)), 2, 3, 4]
+assert r.first[0].values == @[uint8(0 + 1), 2, 3, 4]
 assert r.first[1].count == 2
-assert r.first[1].values == @[uint8((0 + 1)), 2]
+assert r.first[1].values == @[uint8(0 + 1), 2]
 assert r.first[2].count == 0
 assert len(r.second) == 4
 assert r.second[0].count == 6
-assert r.second[0].values == @[uint16((0 + 1)), 2, 3, 4, 5, 6]
+assert r.second[0].values == @[uint16(0 + 1), 2, 3, 4, 5, 6]
 assert r.second[1].count == 3
-assert r.second[1].values == @[uint16((0 + 1)), 2, 3]
+assert r.second[1].values == @[uint16(0 + 1), 2, 3]
 assert r.second[2].count == 4
-assert r.second[2].values == @[uint16((0 + 1)), 2, 3, 4]
+assert r.second[2].values == @[uint16(0 + 1), 2, 3, 4]
 assert r.second[3].count == 0
-assert r.third == @[uint8((0 + 102)), 111, 111, 98, 97, 114, 0]
+assert r.third == @[uint8(0 + 102), 111, 111, 98, 97, 114, 0]

--- a/translator/src/main/scala/io/kaitai/struct/testtranslator/specgenerators/BaseGenerator.scala
+++ b/translator/src/main/scala/io/kaitai/struct/testtranslator/specgenerators/BaseGenerator.scala
@@ -23,7 +23,7 @@ abstract class BaseGenerator(spec: TestSpec) extends SpecGenerator {
 
   def floatEquality(check: TestEquals): Unit = simpleEquality(check)
 
-  def nullAssert(actual: Ast.expr): Unit
+  def nullAssert(actual: Ast.expr, actType: DataType): Unit
 
   def trueArrayEquality(check: TestEquals, elType: DataType, elts: Seq[Ast.expr]): Unit
 
@@ -49,12 +49,12 @@ abstract class BaseGenerator(spec: TestSpec) extends SpecGenerator {
     spec.asserts.foreach { assert =>
       assert match {
         case check: TestEquals =>
+          val actType = translator.detectType(check.actual)
           check.expected match {
             case Ast.expr.Name(Ast.identifier("null")) =>
-              nullAssert(check.actual)
+              nullAssert(check.actual, actType)
             case Ast.expr.List(elts) =>
               // array assert
-              val actType = translator.detectType(check.actual)
               actType match {
                 case bt: BytesType =>
                   // byte array => simple assert
@@ -64,7 +64,6 @@ abstract class BaseGenerator(spec: TestSpec) extends SpecGenerator {
                   trueArrayEquality(check, at.elType, elts)
               }
             case _ =>
-              val actType = translator.detectType(check.actual)
               actType match {
                 case _: FloatType =>
                   floatEquality(check)

--- a/translator/src/main/scala/io/kaitai/struct/testtranslator/specgenerators/CSharpSG.scala
+++ b/translator/src/main/scala/io/kaitai/struct/testtranslator/specgenerators/CSharpSG.scala
@@ -75,7 +75,7 @@ class CSharpSG(spec: TestSpec, provider: ClassTypeProvider) extends BaseGenerato
     out.puts(s"Assert.AreEqual($actStr, $expStr, $FLOAT_DELTA);")
   }
 
-  override def nullAssert(actual: Ast.expr): Unit = {
+  override def nullAssert(actual: Ast.expr, actType: DataType): Unit = {
     val actStr = translateAct(actual)
     out.puts(s"Assert.IsNull($actStr);")
   }

--- a/translator/src/main/scala/io/kaitai/struct/testtranslator/specgenerators/ConstructSG.scala
+++ b/translator/src/main/scala/io/kaitai/struct/testtranslator/specgenerators/ConstructSG.scala
@@ -42,7 +42,7 @@ class ConstructSG(spec: TestSpec, provider: ClassTypeProvider) extends BaseGener
     out.puts(s"self.assertAlmostEqual($actStr, $expStr, 6)")
   }
 
-  override def nullAssert(actual: Ast.expr): Unit = {
+  override def nullAssert(actual: Ast.expr, actType: DataType): Unit = {
     val actStr = translateAct(actual)
     out.puts(s"self.assertIsNone($actStr)")
   }

--- a/translator/src/main/scala/io/kaitai/struct/testtranslator/specgenerators/CppStlSG.scala
+++ b/translator/src/main/scala/io/kaitai/struct/testtranslator/specgenerators/CppStlSG.scala
@@ -73,7 +73,7 @@ class CppStlSG(spec: TestSpec, provider: ClassTypeProvider, cppConfig: CppRuntim
     out.puts(s"BOOST_CHECK_CLOSE($actStr, $expStr, 1e-4);")
   }
 
-  override def nullAssert(actual: Ast.expr): Unit = {
+  override def nullAssert(actual: Ast.expr, actType: DataType): Unit = {
     val nullCheckStr = actual match {
       case Ast.expr.Attribute(x, Ast.identifier(attrName)) =>
         translateAct(x) + s"->_is_null_$attrName()"

--- a/translator/src/main/scala/io/kaitai/struct/testtranslator/specgenerators/GoSG.scala
+++ b/translator/src/main/scala/io/kaitai/struct/testtranslator/specgenerators/GoSG.scala
@@ -101,7 +101,7 @@ class GoSG(spec: TestSpec, provider: ClassTypeProvider) extends BaseGenerator(sp
     out.puts(s"assert.InDelta(t, $expStr, $actStr, $FLOAT_DELTA)")
   }
 
-  def nullAssert(actual: Ast.expr): Unit = {
+  def nullAssert(actual: Ast.expr, actType: DataType): Unit = {
     importList.add("\"github.com/stretchr/testify/assert\"")
     val actStr = translateAct(actual)
     out.puts(s"assert.Nil(t, $actStr)")

--- a/translator/src/main/scala/io/kaitai/struct/testtranslator/specgenerators/JavaSG.scala
+++ b/translator/src/main/scala/io/kaitai/struct/testtranslator/specgenerators/JavaSG.scala
@@ -106,7 +106,7 @@ class JavaSG(spec: TestSpec, provider: ClassTypeProvider) extends BaseGenerator(
     out.puts(s"assertEquals($actStr, $expStr, $FLOAT_DELTA);")
   }
 
-  override def nullAssert(actual: Ast.expr): Unit = {
+  override def nullAssert(actual: Ast.expr, actType: DataType): Unit = {
     val actStr = translateAct(actual)
     out.puts(s"assertNull($actStr);")
   }

--- a/translator/src/main/scala/io/kaitai/struct/testtranslator/specgenerators/JavaScriptSG.scala
+++ b/translator/src/main/scala/io/kaitai/struct/testtranslator/specgenerators/JavaScriptSG.scala
@@ -78,7 +78,7 @@ class JavaScriptSG(spec: TestSpec, provider: ClassTypeProvider) extends BaseGene
     out.puts(s"assert(Math.abs($actStr - $expStr) < $FLOAT_DELTA);")
   }
 
-  override def nullAssert(actual: Ast.expr): Unit = {
+  override def nullAssert(actual: Ast.expr, actType: DataType): Unit = {
     val actStr = translateAct(actual)
     out.puts(s"assert.strictEqual($actStr, undefined);")
   }

--- a/translator/src/main/scala/io/kaitai/struct/testtranslator/specgenerators/LuaSG.scala
+++ b/translator/src/main/scala/io/kaitai/struct/testtranslator/specgenerators/LuaSG.scala
@@ -61,7 +61,7 @@ class LuaSG(spec: TestSpec, provider: ClassTypeProvider) extends BaseGenerator(s
     out.puts(s"luaunit.assertAlmostEquals($actStr, $expStr, 0.000001)")
   }
 
-  override def nullAssert(actual: Ast.expr): Unit = {
+  override def nullAssert(actual: Ast.expr, actType: DataType): Unit = {
     val actStr = translateAct(actual)
     out.puts(s"luaunit.assertNil($actStr)")
   }

--- a/translator/src/main/scala/io/kaitai/struct/testtranslator/specgenerators/NimSG.scala
+++ b/translator/src/main/scala/io/kaitai/struct/testtranslator/specgenerators/NimSG.scala
@@ -23,7 +23,7 @@ class NimSG(spec: TestSpec, provider: ClassTypeProvider) extends BaseGenerator(s
     out.puts(s"let r = ${className}.fromFile" + "(\"../../src/" + spec.data + "\")")
   }
   override def footer(): Unit = { }
-  override def nullAssert(actual: expr): Unit = {
+  override def nullAssert(actual: expr, actType: DataType): Unit = {
     val actStr = translateAct(actual)
     val td = new TypeDetector(provider)
     val expStr = td.detectType(actual) match {

--- a/translator/src/main/scala/io/kaitai/struct/testtranslator/specgenerators/NimSG.scala
+++ b/translator/src/main/scala/io/kaitai/struct/testtranslator/specgenerators/NimSG.scala
@@ -25,8 +25,7 @@ class NimSG(spec: TestSpec, provider: ClassTypeProvider) extends BaseGenerator(s
   override def footer(): Unit = { }
   override def nullAssert(actual: expr, actType: DataType): Unit = {
     val actStr = translateAct(actual)
-    val td = new TypeDetector(provider)
-    val expStr = td.detectType(actual) match {
+    val expStr = actType match {
       case Int1Type(false) => "0'u8"
       case IntMultiType(false, Width2, _) => "0'u16"
       case IntMultiType(false, Width4, _) => "0'u32"

--- a/translator/src/main/scala/io/kaitai/struct/testtranslator/specgenerators/PHPSG.scala
+++ b/translator/src/main/scala/io/kaitai/struct/testtranslator/specgenerators/PHPSG.scala
@@ -53,7 +53,7 @@ class PHPSG(spec: TestSpec, provider: ClassTypeProvider) extends BaseGenerator(s
     out.puts(s"$$this->assertEquals($actStr, $expStr, '', $FLOAT_DELTA);")
   }
 
-  override def nullAssert(actual: Ast.expr): Unit = {
+  override def nullAssert(actual: Ast.expr, actType: DataType): Unit = {
     val actStr = translateAct(actual)
     out.puts(s"$$this->assertNull($actStr);")
   }

--- a/translator/src/main/scala/io/kaitai/struct/testtranslator/specgenerators/PerlSG.scala
+++ b/translator/src/main/scala/io/kaitai/struct/testtranslator/specgenerators/PerlSG.scala
@@ -67,7 +67,7 @@ class PerlSG(spec: TestSpec, provider: ClassTypeProvider) extends BaseGenerator(
     out.puts(s"ok(abs($actStr - $expStr) < $FLOAT_DELTA, 'Approx equals');")
   }
 
-  override def nullAssert(actual: Ast.expr): Unit = {
+  override def nullAssert(actual: Ast.expr, actType: DataType): Unit = {
     val actStr = translateAct(actual)
     out.puts(s"ok(!defined($actStr), 'nil');")
   }

--- a/translator/src/main/scala/io/kaitai/struct/testtranslator/specgenerators/PythonSG.scala
+++ b/translator/src/main/scala/io/kaitai/struct/testtranslator/specgenerators/PythonSG.scala
@@ -73,7 +73,7 @@ class PythonSG(spec: TestSpec, provider: ClassTypeProvider) extends BaseGenerato
     out.puts(s"self.assertAlmostEqual($actStr, $expStr, 6)")
   }
 
-  override def nullAssert(actual: Ast.expr): Unit = {
+  override def nullAssert(actual: Ast.expr, actType: DataType): Unit = {
     val actStr = translateAct(actual)
     out.puts(s"self.assertIsNone($actStr)")
   }

--- a/translator/src/main/scala/io/kaitai/struct/testtranslator/specgenerators/RubySG.scala
+++ b/translator/src/main/scala/io/kaitai/struct/testtranslator/specgenerators/RubySG.scala
@@ -57,7 +57,7 @@ class RubySG(spec: TestSpec, provider: ClassTypeProvider) extends BaseGenerator(
     out.puts(s"expect($actStr).to be_within($FLOAT_DELTA).of $expStr")
   }
 
-  override def nullAssert(actual: Ast.expr): Unit = {
+  override def nullAssert(actual: Ast.expr, actType: DataType): Unit = {
     val actStr = translateAct(actual)
     out.puts(s"expect($actStr).to be_nil")
   }

--- a/translator/src/main/scala/io/kaitai/struct/testtranslator/specgenerators/RustSG.scala
+++ b/translator/src/main/scala/io/kaitai/struct/testtranslator/specgenerators/RustSG.scala
@@ -59,7 +59,7 @@ class RustSG(spec: TestSpec, provider: ClassTypeProvider) extends BaseGenerator(
     out.puts(s"assert_eq!($actStr, $expStr);")
   }
 
-  override def nullAssert(actual: Ast.expr): Unit = {
+  override def nullAssert(actual: Ast.expr, actType: DataType): Unit = {
     val actStr = translator.remove_deref(translateAct(actual))
     out.puts(s"assert!($actStr.is_none());")
   }

--- a/translator/src/main/scala/io/kaitai/struct/testtranslator/specgenerators/ZigSG.scala
+++ b/translator/src/main/scala/io/kaitai/struct/testtranslator/specgenerators/ZigSG.scala
@@ -76,7 +76,7 @@ class ZigSG(spec: TestSpec, provider: ClassTypeProvider) extends BaseGenerator(s
     }
   }
 
-  override def nullAssert(actual: Ast.expr): Unit = {
+  override def nullAssert(actual: Ast.expr, actType: DataType): Unit = {
     val actStr = translateAct(actual)
     val actStrWithoutUnwrap = actStr.stripSuffix(".?")
     out.puts(s"try _imp_std.testing.expectEqual(null, $actStrWithoutUnwrap);")


### PR DESCRIPTION
This PR regenerates Nim tests to reduce possible noise in the future when something may change in the generator. It is focused only on functional changes. Changes in empty lines which creates most noise are done in #142.