### PR TITLE
C++: Use the same precision 1e-6 as for other languages for floating-point checks

### DIFF
--- a/spec/cpp_stl_11/test_expr_array.cpp
+++ b/spec/cpp_stl_11/test_expr_array.cpp
@@ -17,10 +17,10 @@ BOOST_AUTO_TEST_CASE(test_expr_array) {
     BOOST_CHECK_EQUAL(r->aint_min(), 49185);
     BOOST_CHECK_EQUAL(r->aint_max(), 1123362332);
     BOOST_CHECK_EQUAL(r->afloat_size(), 3);
-    BOOST_CHECK_CLOSE(r->afloat_first(), -2.6839530254859364E-121, 1e-4);
-    BOOST_CHECK_CLOSE(r->afloat_last(), -1.1103359815095273E-175, 1e-4);
-    BOOST_CHECK_CLOSE(r->afloat_min(), -8.754689149998834E+288, 1e-4);
-    BOOST_CHECK_CLOSE(r->afloat_max(), -1.1103359815095273E-175, 1e-4);
+    BOOST_CHECK_CLOSE(r->afloat_first(), -2.6839530254859364E-121, 1e-6);
+    BOOST_CHECK_CLOSE(r->afloat_last(), -1.1103359815095273E-175, 1e-6);
+    BOOST_CHECK_CLOSE(r->afloat_min(), -8.754689149998834E+288, 1e-6);
+    BOOST_CHECK_CLOSE(r->afloat_max(), -1.1103359815095273E-175, 1e-6);
     BOOST_CHECK_EQUAL(r->astr_size(), 3);
     BOOST_CHECK_EQUAL(r->astr_first(), std::string("foo"));
     BOOST_CHECK_EQUAL(r->astr_last(), std::string("baz"));

--- a/spec/cpp_stl_11/test_expr_calc_array_ops.cpp
+++ b/spec/cpp_stl_11/test_expr_calc_array_ops.cpp
@@ -18,11 +18,11 @@ BOOST_AUTO_TEST_CASE(test_expr_calc_array_ops) {
     BOOST_CHECK_EQUAL(r->int_array_min(), 10);
     BOOST_CHECK_EQUAL(r->int_array_max(), 1000);
     BOOST_CHECK_EQUAL(r->double_array_size(), 5);
-    BOOST_CHECK_CLOSE(r->double_array_first(), 10.0, 1e-4);
-    BOOST_CHECK_CLOSE(r->double_array_mid(), 25.0, 1e-4);
-    BOOST_CHECK_CLOSE(r->double_array_last(), 3.14159, 1e-4);
-    BOOST_CHECK_CLOSE(r->double_array_min(), 3.14159, 1e-4);
-    BOOST_CHECK_CLOSE(r->double_array_max(), 100.0, 1e-4);
+    BOOST_CHECK_CLOSE(r->double_array_first(), 10.0, 1e-6);
+    BOOST_CHECK_CLOSE(r->double_array_mid(), 25.0, 1e-6);
+    BOOST_CHECK_CLOSE(r->double_array_last(), 3.14159, 1e-6);
+    BOOST_CHECK_CLOSE(r->double_array_min(), 3.14159, 1e-6);
+    BOOST_CHECK_CLOSE(r->double_array_max(), 100.0, 1e-6);
     BOOST_CHECK_EQUAL(r->str_array_size(), 4);
     BOOST_CHECK_EQUAL(r->str_array_first(), std::string("un"));
     BOOST_CHECK_EQUAL(r->str_array_mid(), std::string("deux"));

--- a/spec/cpp_stl_11/test_float_to_i.cpp
+++ b/spec/cpp_stl_11/test_float_to_i.cpp
@@ -10,10 +10,10 @@ BOOST_AUTO_TEST_CASE(test_float_to_i) {
     std::ifstream ifs("src/floating_points.bin", std::ifstream::binary);
     kaitai::kstream ks(&ifs);
     float_to_i_t* r = new float_to_i_t(&ks);
-    BOOST_CHECK_CLOSE(r->single_value(), 0.5, 1e-4);
-    BOOST_CHECK_CLOSE(r->double_value(), 0.25, 1e-4);
-    BOOST_CHECK_CLOSE(r->single_value_if(), 0.5, 1e-4);
-    BOOST_CHECK_CLOSE(r->double_value_if(), 0.25, 1e-4);
+    BOOST_CHECK_CLOSE(r->single_value(), 0.5, 1e-6);
+    BOOST_CHECK_CLOSE(r->double_value(), 0.25, 1e-6);
+    BOOST_CHECK_CLOSE(r->single_value_if(), 0.5, 1e-6);
+    BOOST_CHECK_CLOSE(r->double_value_if(), 0.25, 1e-6);
     BOOST_CHECK_EQUAL(r->single_i(), 0);
     BOOST_CHECK_EQUAL(r->double_i(), 0);
     BOOST_CHECK_EQUAL(r->single_if_i(), 0);

--- a/spec/cpp_stl_11/test_floating_points.cpp
+++ b/spec/cpp_stl_11/test_floating_points.cpp
@@ -11,14 +11,14 @@ BOOST_AUTO_TEST_CASE(test_floating_points) {
     kaitai::kstream ks(&ifs);
     floating_points_t* r = new floating_points_t(&ks);
 
-    BOOST_CHECK_CLOSE(r->single_value(), static_cast<float>(0.5), 1e-4);
-    BOOST_CHECK_CLOSE(r->single_value_be(), static_cast<float>(0.5), 1e-4);
-    BOOST_CHECK_CLOSE(r->double_value(), 0.25, 1e-4);
-    BOOST_CHECK_CLOSE(r->double_value_be(), 0.25, 1e-4);
-    BOOST_CHECK_CLOSE(r->approximate_value(), 1.2345, 1e-4);
-    BOOST_CHECK_CLOSE(r->single_value_plus_int(), 1.5, 1e-4);
-    BOOST_CHECK_CLOSE(r->single_value_plus_float(), 1.0, 1e-4);
-    BOOST_CHECK_CLOSE(r->double_value_plus_float(), 0.3, 1e-4);
+    BOOST_CHECK_CLOSE(r->single_value(), static_cast<float>(0.5), 1e-6);
+    BOOST_CHECK_CLOSE(r->single_value_be(), static_cast<float>(0.5), 1e-6);
+    BOOST_CHECK_CLOSE(r->double_value(), 0.25, 1e-6);
+    BOOST_CHECK_CLOSE(r->double_value_be(), 0.25, 1e-6);
+    BOOST_CHECK_CLOSE(r->approximate_value(), 1.2345, 1e-6);
+    BOOST_CHECK_CLOSE(r->single_value_plus_int(), 1.5, 1e-6);
+    BOOST_CHECK_CLOSE(r->single_value_plus_float(), 1.0, 1e-6);
+    BOOST_CHECK_CLOSE(r->double_value_plus_float(), 0.3, 1e-6);
 
     delete r;
 }

--- a/spec/cpp_stl_11/test_type_ternary_2nd_falsy.cpp
+++ b/spec/cpp_stl_11/test_type_ternary_2nd_falsy.cpp
@@ -12,8 +12,8 @@ BOOST_AUTO_TEST_CASE(test_type_ternary_2nd_falsy) {
     BOOST_CHECK_EQUAL(r->v_false(), false);
     BOOST_CHECK_EQUAL(r->v_int_zero(), 0);
     BOOST_CHECK_EQUAL(r->v_int_neg_zero(), -0);
-    BOOST_CHECK_CLOSE(r->v_float_zero(), 0.0, 1e-4);
-    BOOST_CHECK_CLOSE(r->v_float_neg_zero(), -0.0, 1e-4);
+    BOOST_CHECK_CLOSE(r->v_float_zero(), 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(r->v_float_neg_zero(), -0.0, 1e-6);
     BOOST_CHECK_EQUAL(r->v_str_w_zero(), std::string("0"));
     BOOST_CHECK_EQUAL(r->v_str_w_zero().length(), 1);
     BOOST_CHECK_EQUAL(r->ut()->m(), 7);

--- a/spec/cpp_stl_98/test_expr_array.cpp
+++ b/spec/cpp_stl_98/test_expr_array.cpp
@@ -17,10 +17,10 @@ BOOST_AUTO_TEST_CASE(test_expr_array) {
     BOOST_CHECK_EQUAL(r->aint_min(), 49185);
     BOOST_CHECK_EQUAL(r->aint_max(), 1123362332);
     BOOST_CHECK_EQUAL(r->afloat_size(), 3);
-    BOOST_CHECK_CLOSE(r->afloat_first(), -2.6839530254859364E-121, 1e-4);
-    BOOST_CHECK_CLOSE(r->afloat_last(), -1.1103359815095273E-175, 1e-4);
-    BOOST_CHECK_CLOSE(r->afloat_min(), -8.754689149998834E+288, 1e-4);
-    BOOST_CHECK_CLOSE(r->afloat_max(), -1.1103359815095273E-175, 1e-4);
+    BOOST_CHECK_CLOSE(r->afloat_first(), -2.6839530254859364E-121, 1e-6);
+    BOOST_CHECK_CLOSE(r->afloat_last(), -1.1103359815095273E-175, 1e-6);
+    BOOST_CHECK_CLOSE(r->afloat_min(), -8.754689149998834E+288, 1e-6);
+    BOOST_CHECK_CLOSE(r->afloat_max(), -1.1103359815095273E-175, 1e-6);
     BOOST_CHECK_EQUAL(r->astr_size(), 3);
     BOOST_CHECK_EQUAL(r->astr_first(), std::string("foo"));
     BOOST_CHECK_EQUAL(r->astr_last(), std::string("baz"));

--- a/spec/cpp_stl_98/test_expr_calc_array_ops.cpp
+++ b/spec/cpp_stl_98/test_expr_calc_array_ops.cpp
@@ -18,11 +18,11 @@ BOOST_AUTO_TEST_CASE(test_expr_calc_array_ops) {
     BOOST_CHECK_EQUAL(r->int_array_min(), 10);
     BOOST_CHECK_EQUAL(r->int_array_max(), 1000);
     BOOST_CHECK_EQUAL(r->double_array_size(), 5);
-    BOOST_CHECK_CLOSE(r->double_array_first(), 10.0, 1e-4);
-    BOOST_CHECK_CLOSE(r->double_array_mid(), 25.0, 1e-4);
-    BOOST_CHECK_CLOSE(r->double_array_last(), 3.14159, 1e-4);
-    BOOST_CHECK_CLOSE(r->double_array_min(), 3.14159, 1e-4);
-    BOOST_CHECK_CLOSE(r->double_array_max(), 100.0, 1e-4);
+    BOOST_CHECK_CLOSE(r->double_array_first(), 10.0, 1e-6);
+    BOOST_CHECK_CLOSE(r->double_array_mid(), 25.0, 1e-6);
+    BOOST_CHECK_CLOSE(r->double_array_last(), 3.14159, 1e-6);
+    BOOST_CHECK_CLOSE(r->double_array_min(), 3.14159, 1e-6);
+    BOOST_CHECK_CLOSE(r->double_array_max(), 100.0, 1e-6);
     BOOST_CHECK_EQUAL(r->str_array_size(), 4);
     BOOST_CHECK_EQUAL(r->str_array_first(), std::string("un"));
     BOOST_CHECK_EQUAL(r->str_array_mid(), std::string("deux"));

--- a/spec/cpp_stl_98/test_float_to_i.cpp
+++ b/spec/cpp_stl_98/test_float_to_i.cpp
@@ -10,10 +10,10 @@ BOOST_AUTO_TEST_CASE(test_float_to_i) {
     std::ifstream ifs("src/floating_points.bin", std::ifstream::binary);
     kaitai::kstream ks(&ifs);
     float_to_i_t* r = new float_to_i_t(&ks);
-    BOOST_CHECK_CLOSE(r->single_value(), 0.5, 1e-4);
-    BOOST_CHECK_CLOSE(r->double_value(), 0.25, 1e-4);
-    BOOST_CHECK_CLOSE(r->single_value_if(), 0.5, 1e-4);
-    BOOST_CHECK_CLOSE(r->double_value_if(), 0.25, 1e-4);
+    BOOST_CHECK_CLOSE(r->single_value(), 0.5, 1e-6);
+    BOOST_CHECK_CLOSE(r->double_value(), 0.25, 1e-6);
+    BOOST_CHECK_CLOSE(r->single_value_if(), 0.5, 1e-6);
+    BOOST_CHECK_CLOSE(r->double_value_if(), 0.25, 1e-6);
     BOOST_CHECK_EQUAL(r->single_i(), 0);
     BOOST_CHECK_EQUAL(r->double_i(), 0);
     BOOST_CHECK_EQUAL(r->single_if_i(), 0);

--- a/spec/cpp_stl_98/test_floating_points.cpp
+++ b/spec/cpp_stl_98/test_floating_points.cpp
@@ -11,14 +11,14 @@ BOOST_AUTO_TEST_CASE(test_floating_points) {
     kaitai::kstream ks(&ifs);
     floating_points_t* r = new floating_points_t(&ks);
 
-    BOOST_CHECK_CLOSE(r->single_value(), static_cast<float>(0.5), 1e-4);
-    BOOST_CHECK_CLOSE(r->single_value_be(), static_cast<float>(0.5), 1e-4);
-    BOOST_CHECK_CLOSE(r->double_value(), 0.25, 1e-4);
-    BOOST_CHECK_CLOSE(r->double_value_be(), 0.25, 1e-4);
-    BOOST_CHECK_CLOSE(r->approximate_value(), 1.2345, 1e-4);
-    BOOST_CHECK_CLOSE(r->single_value_plus_int(), 1.5, 1e-4);
-    BOOST_CHECK_CLOSE(r->single_value_plus_float(), 1.0, 1e-4);
-    BOOST_CHECK_CLOSE(r->double_value_plus_float(), 0.3, 1e-4);
+    BOOST_CHECK_CLOSE(r->single_value(), static_cast<float>(0.5), 1e-6);
+    BOOST_CHECK_CLOSE(r->single_value_be(), static_cast<float>(0.5), 1e-6);
+    BOOST_CHECK_CLOSE(r->double_value(), 0.25, 1e-6);
+    BOOST_CHECK_CLOSE(r->double_value_be(), 0.25, 1e-6);
+    BOOST_CHECK_CLOSE(r->approximate_value(), 1.2345, 1e-6);
+    BOOST_CHECK_CLOSE(r->single_value_plus_int(), 1.5, 1e-6);
+    BOOST_CHECK_CLOSE(r->single_value_plus_float(), 1.0, 1e-6);
+    BOOST_CHECK_CLOSE(r->double_value_plus_float(), 0.3, 1e-6);
 
     delete r;
 }

--- a/spec/cpp_stl_98/test_type_ternary_2nd_falsy.cpp
+++ b/spec/cpp_stl_98/test_type_ternary_2nd_falsy.cpp
@@ -12,8 +12,8 @@ BOOST_AUTO_TEST_CASE(test_type_ternary_2nd_falsy) {
     BOOST_CHECK_EQUAL(r->v_false(), false);
     BOOST_CHECK_EQUAL(r->v_int_zero(), 0);
     BOOST_CHECK_EQUAL(r->v_int_neg_zero(), -0);
-    BOOST_CHECK_CLOSE(r->v_float_zero(), 0.0, 1e-4);
-    BOOST_CHECK_CLOSE(r->v_float_neg_zero(), -0.0, 1e-4);
+    BOOST_CHECK_CLOSE(r->v_float_zero(), 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(r->v_float_neg_zero(), -0.0, 1e-6);
     BOOST_CHECK_EQUAL(r->v_str_w_zero(), std::string("0"));
     BOOST_CHECK_EQUAL(r->v_str_w_zero().length(), 1);
     BOOST_CHECK_EQUAL(r->ut()->m(), 7);

--- a/translator/src/main/scala/io/kaitai/struct/testtranslator/specgenerators/CppStlSG.scala
+++ b/translator/src/main/scala/io/kaitai/struct/testtranslator/specgenerators/CppStlSG.scala
@@ -70,7 +70,7 @@ class CppStlSG(spec: TestSpec, provider: ClassTypeProvider, cppConfig: CppRuntim
   override def floatEquality(check: TestEquals): Unit = {
     val actStr = translateAct(check.actual)
     val expStr = translator.translate(check.expected)
-    out.puts(s"BOOST_CHECK_CLOSE($actStr, $expStr, 1e-4);")
+    out.puts(s"BOOST_CHECK_CLOSE($actStr, $expStr, 1e-6);")
   }
 
   override def nullAssert(actual: Ast.expr): Unit = {


### PR DESCRIPTION
It seems that current 1e-4 was chosen arbitrately in 224ae5c90c68084d3fd7f920663ea105dd31f77a. I do not see any needs to use more tolerant check for C++ in comparison to other languages. For example, Lua and JavaScript uses `double` for representing numbers and they making checks using tolerance of 1e-6.